### PR TITLE
resolves #33 Fix carousel bad scroll behaviour

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -103,14 +103,14 @@ export interface CardProps {
     sendAction: (button: Button) => void;
 }
 
-const Card: (props: CardProps) => JSX.Element = ({
-                                                     title,
-                                                     subTitle,
-                                                     imageUrl,
-                                                     buttons,
-                                                     sendAction
-                                                 }: CardProps) => (
-    <CardOuter>
+const Card = React.forwardRef<HTMLDivElement, CardProps>(({
+    title,
+    subTitle,
+    imageUrl,
+    buttons,
+    sendAction
+}, ref) => (
+    <CardOuter ref={ref}>
         <CardContainer>
             {imageUrl ? <CardImage src={imageUrl} alt={title}/> : null}
             <CardTitle>{title}</CardTitle>
@@ -133,6 +133,6 @@ const Card: (props: CardProps) => JSX.Element = ({
             ) : null}
         </CardContainer>
     </CardOuter>
-);
+));
 
 export default Card;

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -125,7 +125,7 @@ const Carousel: (props: { children?: ReactElement<any>[] }) => JSX.Element = ({
     previous,
     next
   ] = useCarousel<HTMLDivElement>(children?.length)
-  const [leftVisible, rightVisible] = useArrowVisibility(ref.container)
+  const [leftVisible, rightVisible] = useArrowVisibility(ref.container, ref.items)
 
   return (
     <ButtonContainer>

--- a/src/components/Carousel/hooks/useArrowVisibility.ts
+++ b/src/components/Carousel/hooks/useArrowVisibility.ts
@@ -3,24 +3,29 @@ import {
   useState,
   useEffect,
   useCallback
-} from 'react'
+} from 'react';
 
-export default function useArrowVisibility(ref: RefObject<HTMLElement>): [boolean, boolean] {
-  const [visibility, setVisibility] = useState<[boolean, boolean]>([false, true])
+export default function useArrowVisibility(
+  ref: RefObject<HTMLElement>,
+  itemRefs: RefObject<HTMLElement>[]
+): [boolean, boolean] {
+  const [visibility, setVisibility] = useState<[boolean, boolean]>([false, true]);
 
   const computeVisibility = useCallback(() => {
     if (!ref.current) return;
     const {
-      scrollLeft,
-      clientWidth,
-      scrollWidth
+      scrollLeft = 0,
+      clientWidth = 0,
+      scrollWidth = 0
     } = ref.current;
     const leftVisibility = scrollLeft > 0;
     const rightVisibility = scrollLeft + clientWidth < scrollWidth;
     if (visibility[0] !== leftVisibility || visibility[1] !== rightVisibility) {
-      setVisibility([leftVisibility, rightVisibility])
+      setVisibility([leftVisibility, rightVisibility]);
     }
-  }, [ref.current, visibility, setVisibility])
+  }, [ref.current, visibility, setVisibility]);
+
+  useEffect(computeVisibility, [itemRefs]);
 
   useEffect(() => {
     if (!ref.current) return;
@@ -30,7 +35,7 @@ export default function useArrowVisibility(ref: RefObject<HTMLElement>): [boolea
       ref.current?.removeEventListener('resize', computeVisibility);
       ref.current?.removeEventListener('scroll', computeVisibility);
     }
-  }, [ref.current])
+  }, [ref.current, visibility]);
 
-  return visibility
-}
+  return visibility;
+};

--- a/src/components/Carousel/hooks/useArrowVisibility.ts
+++ b/src/components/Carousel/hooks/useArrowVisibility.ts
@@ -1,0 +1,36 @@
+import {
+  RefObject,
+  useState,
+  useEffect,
+  useCallback
+} from 'react'
+
+export default function useArrowVisibility(ref: RefObject<HTMLElement>): [boolean, boolean] {
+  const [visibility, setVisibility] = useState<[boolean, boolean]>([false, true])
+
+  const computeVisibility = useCallback(() => {
+    if (!ref.current) return;
+    const {
+      scrollLeft,
+      clientWidth,
+      scrollWidth
+    } = ref.current;
+    const leftVisibility = scrollLeft > 0;
+    const rightVisibility = scrollLeft + clientWidth < scrollWidth;
+    if (visibility[0] !== leftVisibility || visibility[1] !== rightVisibility) {
+      setVisibility([leftVisibility, rightVisibility])
+    }
+  }, [ref.current, visibility, setVisibility])
+
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.addEventListener('resize', computeVisibility);
+    ref.current.addEventListener('scroll', computeVisibility);
+    return () => {
+      ref.current?.removeEventListener('resize', computeVisibility);
+      ref.current?.removeEventListener('scroll', computeVisibility);
+    }
+  }, [ref.current])
+
+  return visibility
+}

--- a/src/components/Carousel/hooks/useCarousel.ts
+++ b/src/components/Carousel/hooks/useCarousel.ts
@@ -1,0 +1,70 @@
+import {
+  RefObject,
+  useRef,
+  useCallback
+} from 'react'
+import useRefs from './useRefs'
+import useMeasures, { Measure } from './useMeasures'
+
+type Ref = RefObject<HTMLElement>
+type Refs = Array<Ref>
+
+type CarouselScrollReturn<T> = [
+  {
+    container: RefObject<T>,
+    items: Refs,
+  },
+  (() => void),
+  (() => void)
+]
+
+function scrollStep(
+  direction: 1 | -1,
+  container: HTMLElement | null,
+  measures: Measure[]
+) {
+  if (!container) return;
+  const x = container.scrollLeft
+  const width = container.clientWidth
+
+  if (direction === 1) {
+    const rightMeasure = measures.find(measure => measure.x + measure.width > x + width)
+    container.scrollLeft = rightMeasure?.x || 0
+  } else {
+    const leftMeasure = measures.find(measure => measure.x + width >= x)
+    container.scrollLeft = leftMeasure?.x || 0
+  }
+}
+
+export default function useCarousel<T>(itemCount: number = 0) : CarouselScrollReturn<T> {
+  const containerRef = useRef(null);
+  const itemRefs = useRefs(itemCount);
+  const measures = useMeasures(itemRefs);
+
+  const previous = useCallback(() =>
+    scrollStep(
+      -1,
+      containerRef.current,
+      measures
+    ),
+    [containerRef, measures]
+  )
+
+  const next = useCallback(() =>
+    scrollStep(
+      1,
+      containerRef.current,
+      measures
+    ),
+    [containerRef, measures]
+  )
+
+  return [
+    {
+      container: containerRef,
+      items: itemRefs,
+    },
+    previous,
+    next
+  ]
+}

--- a/src/components/Carousel/hooks/useMeasures.ts
+++ b/src/components/Carousel/hooks/useMeasures.ts
@@ -2,31 +2,29 @@ import {
   RefObject,
   useEffect,
   useState
-} from 'react'
-
-type Refs = RefObject<HTMLElement>[]
+} from 'react';
 
 export interface Measure {
-  width: number,
-  height: number,
-  x: number,
-  y: number
-}
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+};
 
-const measureElementWidth = (element: HTMLElement | null) : Measure => ({
+const measureElement = (element: HTMLElement | null) : Measure => ({
   width: element?.clientWidth || 0,
   height: element?.clientHeight || 0,
   x: element?.offsetLeft || 0,
   y: element?.offsetTop || 0
-})
+});
 
-export default function useMeasures(refs: Refs) : Measure[] {
-  const [measures, setMeasures] = useState<Measure[]>([])
+export default function useMeasures(refs: RefObject<HTMLElement>[]) : Measure[] {
+  const [measures, setMeasures] = useState<Measure[]>([]);
 
   useEffect(() => {
-    const nextMeasures = refs.map(ref => measureElementWidth(ref.current))
-    setMeasures(nextMeasures)
-  }, [refs])
+    const nextMeasures = refs.map(ref => measureElement(ref.current));
+    setMeasures(nextMeasures);
+  }, [refs]);
 
-  return measures
-}
+  return measures;
+};

--- a/src/components/Carousel/hooks/useMeasures.ts
+++ b/src/components/Carousel/hooks/useMeasures.ts
@@ -1,0 +1,32 @@
+import {
+  RefObject,
+  useEffect,
+  useState
+} from 'react'
+
+type Refs = RefObject<HTMLElement>[]
+
+export interface Measure {
+  width: number,
+  height: number,
+  x: number,
+  y: number
+}
+
+const measureElementWidth = (element: HTMLElement | null) : Measure => ({
+  width: element?.clientWidth || 0,
+  height: element?.clientHeight || 0,
+  x: element?.offsetLeft || 0,
+  y: element?.offsetTop || 0
+})
+
+export default function useMeasures(refs: Refs) : Measure[] {
+  const [measures, setMeasures] = useState<Measure[]>([])
+
+  useEffect(() => {
+    const nextMeasures = refs.map(ref => measureElementWidth(ref.current))
+    setMeasures(nextMeasures)
+  }, [refs])
+
+  return measures
+}

--- a/src/components/Carousel/hooks/useRefs.ts
+++ b/src/components/Carousel/hooks/useRefs.ts
@@ -1,0 +1,27 @@
+import {
+  RefObject,
+  useState,
+  useEffect,
+  createRef
+} from 'react'
+
+type Refs = RefObject<HTMLElement>[]
+
+export default function useRefs(count: number) : Refs {
+  const [refs, setRefs] = useState<Refs>([])
+
+  useEffect(() => {
+    const initialRefs: Refs = Array.from(Array(count)).map(() => createRef<HTMLElement>())
+    setRefs(initialRefs)
+  }, [])
+  
+  useEffect(() => {
+    setRefs(refs =>
+      Array.from(Array(count)).map((_, i) =>
+        refs[i] || createRef()
+      )
+    )
+  }, [count])
+
+  return refs
+}

--- a/src/components/Carousel/hooks/useRefs.ts
+++ b/src/components/Carousel/hooks/useRefs.ts
@@ -3,25 +3,25 @@ import {
   useState,
   useEffect,
   createRef
-} from 'react'
+} from 'react';
 
-type Refs = RefObject<HTMLElement>[]
+type Refs = RefObject<HTMLElement>[];
 
 export default function useRefs(count: number) : Refs {
-  const [refs, setRefs] = useState<Refs>([])
+  const [refs, setRefs] = useState<Refs>([]);
 
   useEffect(() => {
-    const initialRefs: Refs = Array.from(Array(count)).map(() => createRef<HTMLElement>())
-    setRefs(initialRefs)
-  }, [])
-  
+    const initialRefs = Array.from(Array(count)).map(() => createRef<HTMLElement>());
+    setRefs(initialRefs);
+  }, []);
+
   useEffect(() => {
     setRefs(refs =>
       Array.from(Array(count)).map((_, i) =>
         refs[i] || createRef()
       )
-    )
-  }, [count])
+    );
+  }, [count]);
 
-  return refs
-}
+  return refs;
+};


### PR DESCRIPTION
According to the issue #33 :
  - Button trigger scroll with fully visible cards width as step
  - **(margin is supported)**

In addition:
  - It is handling different items dimension and dynamic items count.
  - It is always fully displaying each cards.