### PR TITLE
resolve #69: Add opening message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,11 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 ### `TockOptions`
 
-| Property name                            | Type              | Description                                               |
-|------------------------------------------|-------------------|-----------------------------------------------------------|
-| `timeoutBetweenMessage`                  | `number?`         | Timeout between message                                   |
-| `widgets`                                | `any?`            | Custom display component                                  |
+| Property name                            | Type              | Description                                                      |
+|------------------------------------------|-------------------|------------------------------------------------------------------|
+| `openingMessage`                         | `string?`         | Initial message to send to the bot to trigger a welcome sequence |
+| `timeoutBetweenMessage`                  | `number?`         | Timeout between message                                          |
+| `widgets`                                | `any?`            | Custom display component                                         |
 
 ## Create custom widget
 

--- a/src/TockOptions.ts
+++ b/src/TockOptions.ts
@@ -1,4 +1,6 @@
 export interface TockOptions {
+  // An initial message to send to the backend to trigger a welcome sequence
+  openingMessage?: string;
   timeoutBetweenMessage?: number;
   widgets?: any;
 }

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -8,6 +8,7 @@ export interface ChatProps {
   endPoint: string;
   referralParameter?: string;
   timeoutBetweenMessage?: number;
+  openingMessage?: string;
   widgets?: any;
 }
 
@@ -15,6 +16,7 @@ const Chat: (props: ChatProps) => JSX.Element = ({
   endPoint,
   referralParameter,
   timeoutBetweenMessage = 700,
+  openingMessage = undefined,
   widgets = {},
 }: ChatProps) => {
   const {
@@ -25,9 +27,16 @@ const Chat: (props: ChatProps) => JSX.Element = ({
     sendQuickReply,
     sendAction,
     sendReferralParameter,
+    sendOpeningMessage,
     sseInitPromise,
     sseInitializing,
   }: UseTock = useTock(endPoint);
+  useEffect(() => {
+    // When the chat gets initialized for the first time, initiate the welcome sequence
+    if (messages.length === 0 && openingMessage) {
+      sendOpeningMessage(openingMessage);
+    }
+  }, []);
 
   useEffect(() => {
     if (referralParameter) {

--- a/src/renderChat.tsx
+++ b/src/renderChat.tsx
@@ -28,6 +28,7 @@ export const renderChat: (
           endPoint={endPoint}
           referralParameter={referralParameter}
           timeoutBetweenMessage={options.timeoutBetweenMessage}
+          openingMessage={options.openingMessage}
           widgets={options.widgets}
         />
       </TockContext>

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -41,6 +41,7 @@ export interface UseTock {
   sendReferralParameter: (referralParameter: string) => void;
   sseInitPromise: Promise<void>;
   sseInitializing: boolean;
+  sendOpeningMessage: (msg: string) => void;
 }
 
 function mapButton(button: any): Button {
@@ -265,6 +266,27 @@ const useTock: (tockEndPoint: string) => UseTock = (tockEndPoint: string) => {
     return Promise.resolve();
   };
 
+  // Sends an initial message to the backend, to trigger a welcome message
+  const sendOpeningMessage: (msg: string) => void = (msg) => {
+    send(msg);
+  };
+
+  // Sends a message directly to the bot backend, without it appearing in the chat
+  const send: (message: string) => void = (message) => {
+    fetch(tockEndPoint, {
+      body: JSON.stringify({
+        query: message,
+        userId,
+      }),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((res) => res.json())
+      .then(handleBotResponse);
+  };
+
   const addCard: (
     title: string,
     imageUrl?: string,
@@ -353,6 +375,7 @@ const useTock: (tockEndPoint: string) => UseTock = (tockEndPoint: string) => {
     sendQuickReply,
     sendAction,
     sendReferralParameter,
+    sendOpeningMessage,
     sseInitPromise,
     sseInitializing,
   };


### PR DESCRIPTION
This PR adds a field to `TockOptions` that let API consumers specify a message that will be sent to the bot when the chat is rendered for the first time. That message will not appear in the chat, which makes it useful to start a welcome sequence (eg. by sending "hello" to the bot).

Example:
```js
renderChat(document.getElementById('chat'), botUrl, '', {/* style elided for brevity */}, {
    openingMessage: 'Hi',
});
```

![image](https://user-images.githubusercontent.com/79657435/121524475-a5c22000-c9f7-11eb-8381-60efd47b8adb.png)
