### PR TITLE
resolve #71: Make Quick Reply buttons wrap over

### DIFF
--- a/src/components/QuickReplyList/QuickReplyList.tsx
+++ b/src/components/QuickReplyList/QuickReplyList.tsx
@@ -15,7 +15,6 @@ const QuickReplyListContainer: StyledComponent<
   max-width: ${prop<any>('theme.sizing.conversation.width')};
   margin: 0.5em auto;
   overflow-x: unset;
-  white-space: nowrap;
   text-align: left;
 
   overflow: auto;


### PR DESCRIPTION
This PR simply makes it so Quick Reply buttons wrap over to the next line when they cannot fit horizontally.

Before:
![image](https://user-images.githubusercontent.com/79657435/124446794-0b989200-dd81-11eb-89ff-55473a04e040.png)

After: 
![image](https://user-images.githubusercontent.com/79657435/124446849-17845400-dd81-11eb-8003-a4c259de8935.png)
