### PR TITLE
resolve #73: Add extra HTTP headers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,11 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 ### `TockOptions`
 
-| Property name                            | Type              | Description                                               |
-|------------------------------------------|-------------------|-----------------------------------------------------------|
-| `timeoutBetweenMessage`                  | `number?`         | Timeout between message                                   |
-| `widgets`                                | `any?`            | Custom display component                                  |
+| Property name                            | Type                                  | Description                                               |
+|------------------------------------------|---------------------------------------|-----------------------------------------------------------|
+| `extraHeadersProvider`                   | `() => Promise<Record<string, string>`| Provider of extra HTTP headers for outgoing requests      |
+| `timeoutBetweenMessage`                  | `number?`                             | Timeout between message                                   |
+| `widgets`                                | `any?`                                | Custom display component                                  |
 
 ## Create custom widget
 

--- a/src/TockOptions.ts
+++ b/src/TockOptions.ts
@@ -1,4 +1,7 @@
 export interface TockOptions {
+  // An optional function supplying extra HTTP headers for chat requests.
+  // Extra headers must be explicitly allowed by the server's CORS settings.
+  extraHeadersProvider?: () => Promise<Record<string, string>>;
   timeoutBetweenMessage?: number;
   widgets?: any;
 }

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -9,6 +9,7 @@ export interface ChatProps {
   referralParameter?: string;
   timeoutBetweenMessage?: number;
   widgets?: any;
+  extraHeadersProvider?: () => Promise<Record<string, string>>;
 }
 
 const Chat: (props: ChatProps) => JSX.Element = ({
@@ -16,6 +17,7 @@ const Chat: (props: ChatProps) => JSX.Element = ({
   referralParameter,
   timeoutBetweenMessage = 700,
   widgets = {},
+  extraHeadersProvider = undefined,
 }: ChatProps) => {
   const {
     messages,
@@ -27,7 +29,7 @@ const Chat: (props: ChatProps) => JSX.Element = ({
     sendReferralParameter,
     sseInitPromise,
     sseInitializing,
-  }: UseTock = useTock(endPoint);
+  }: UseTock = useTock(endPoint, extraHeadersProvider);
 
   useEffect(() => {
     if (referralParameter) {

--- a/src/renderChat.tsx
+++ b/src/renderChat.tsx
@@ -29,6 +29,7 @@ export const renderChat: (
           referralParameter={referralParameter}
           timeoutBetweenMessage={options.timeoutBetweenMessage}
           widgets={options.widgets}
+          extraHeadersProvider={options.extraHeadersProvider}
         />
       </TockContext>
     </ThemeProvider>,


### PR DESCRIPTION
This PR adds the option to specify a provider callback for additional HTTP headers that will be appended to every request made to the bot backend. Note that extra headers have to be allowed by the backend's CORS setup for the application to work as intended.