### PR TITLE
resolve #110: Add afterInit callback

### DIFF
--- a/src/PostInitContext.ts
+++ b/src/PostInitContext.ts
@@ -1,0 +1,26 @@
+import { UseLocalTools } from './useLocalTools';
+import { Messages, QuickReply } from './TockContext';
+
+export interface TockHistoryData {
+  readonly messages: Messages[];
+  readonly quickReplies: QuickReply[];
+}
+
+export interface PostInitContext extends UseLocalTools {
+  /**
+   * The full chat history at the time the Chat component is initialized, which includes messages from local storage
+   * and/or from TockContext, or null if there is no chat history at all.
+   */
+  readonly history: TockHistoryData | null;
+  /**
+   * Sends a regular text message as if typed by a user. The message will be visible in the chat.
+   * @param message an arbitrary string
+   */
+  readonly sendMessage: (message: string) => Promise<void>;
+  /**
+   * Sends a payload to the backend as if a button was triggered.
+   * @param payload a string representing a TOCK intent name, followed by URL-like query parameters
+   */
+  readonly sendPayload: (payload: string) => Promise<void>;
+  readonly clearMessages: () => void;
+}

--- a/src/TockOptions.ts
+++ b/src/TockOptions.ts
@@ -1,14 +1,18 @@
-import TockAccessibility from 'TockAccessibility';
-import TockLocalStorage from 'TockLocalStorage';
+import TockAccessibility from './TockAccessibility';
+import TockLocalStorage from './TockLocalStorage';
+import { PostInitContext } from './PostInitContext';
 
 export interface TockOptions {
+  // a callback that will be executed once the chat is able to send and receive messages
+  afterInit?: (context: PostInitContext) => Promise<void>;
   // An initial message to send to the backend to trigger a welcome sequence
+  // This message will be sent after the afterInit callback runs
   openingMessage?: string;
   // An optional function supplying extra HTTP headers for chat requests.
   // Extra headers must be explicitly allowed by the server's CORS settings.
   extraHeadersProvider?: () => Promise<Record<string, string>>;
   timeoutBetweenMessage?: number;
-  widgets?: any;
+  widgets?: { [id: string]: (props: unknown) => JSX.Element };
   disableSse?: boolean;
   accessibility?: TockAccessibility;
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,5 +31,6 @@ export type {
   Widget as WidgetData,
   WidgetPayload,
 } from './model/messages';
+export type { PostInitContext, TockHistoryData } from './PostInitContext';
 export type TockTheme = _TockTheme;
 export type TockOptions = _TockOptions;


### PR DESCRIPTION
This PR adds a generic callback that can be used to programatically interact with the chat after it loads.

Further questions:
- Should we create and expose an interface separate from `UseTock`, to avoid leaking internals? If so, which methods should we make available in this new interface?
- Should we deprecate the `openingMessage` option, now that it can be substituted with `afterInit: (tock) => tock.sendOpeningMessage(openingMessage)`?

Closes #110 