### PR TITLE
resolves #124 Possibility to indicate a prefix for Local Storage keys

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 |-----------------------------------|------------------------|-----------------------------------------------------------------------------|
 | `enable`                          | `boolean?`             | Enable history local storage                                                |
 | `maxNumberMessages`               | `number?`              | Max number of messages in the history local storage (default 10)            |
+| `storagePrefix`                   | `string?`              | Prefix for local storage keys allowing communication with different bots from the same domain with history            |
 
 #### `CarouselAccessibility`
 

--- a/src/TockContext.tsx
+++ b/src/TockContext.tsx
@@ -8,6 +8,7 @@ import React, {
   useContext,
 } from 'react';
 import { retrieveUserId } from './utils';
+import TockLocalStorage from './TockLocalStorage';
 
 export const TockStateContext: Context<TockState | undefined> = createContext<
   TockState | undefined
@@ -204,17 +205,22 @@ export const tockReducer: Reducer<TockState, TockAction> = (
   return state;
 };
 
-const TockContext: (props: { children?: ReactNode }) => JSX.Element = ({
+const TockContext: (props: {
+  children?: ReactNode;
+  localStorageHistory?: TockLocalStorage;
+}) => JSX.Element = ({
   children,
+  localStorageHistory,
 }: {
   children?: ReactNode;
+  localStorageHistory?: TockLocalStorage;
 }) => {
   const [state, dispatch]: [TockState, Dispatch<TockAction>] = useReducer(
     tockReducer,
     {
       quickReplies: [],
       messages: [],
-      userId: retrieveUserId(),
+      userId: retrieveUserId(localStorageHistory),
       loading: false,
       sseInitializing: false,
     },

--- a/src/TockLocalStorage.ts
+++ b/src/TockLocalStorage.ts
@@ -1,6 +1,7 @@
 export interface TockLocalStorage {
   enable?: boolean;
   maxNumberMessages?: number;
+  storagePrefix?: string;
 }
 
 export default TockLocalStorage;

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -170,7 +170,9 @@ const Carousel: (props: {
           <ArrowRightCircle
             size={`calc(${theme.typography.fontSize} * 2)`}
             role="img"
-            aria-label={accessibility?.carousel?.nextButtonLabel || 'Next slides'}
+            aria-label={
+              accessibility?.carousel?.nextButtonLabel || 'Next slides'
+            }
             focusable="false"
           />
         </Next>

--- a/src/components/Carousel/hooks/useCarousel.ts
+++ b/src/components/Carousel/hooks/useCarousel.ts
@@ -98,9 +98,9 @@ export default function useCarousel<T>(itemCount = 0): CarouselReturn<T> {
   const containerRef = useRef(null);
   const itemRefs = useRefs(itemCount);
   const measures = useMeasures(itemRefs);
-  const carouselItems: CarouselItem[] = Array.from(Array(itemCount)).map<
-    CarouselItem
-  >((_, i) => {
+  const carouselItems: CarouselItem[] = Array.from(
+    Array(itemCount),
+  ).map<CarouselItem>((_, i) => {
     const [isHidden, setIsHidden] = useState(false);
     return Object.create({ refObject: itemRefs[i++], isHidden, setIsHidden });
   });

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -5,7 +5,7 @@ import Container from '../Container';
 import Conversation from '../Conversation';
 import TockAccessibility from '../../TockAccessibility';
 import TockLocalStorage from 'TockLocalStorage';
-import { retrievePrefixedLocalStorageKeyName } from '../../utils';
+import { retrievePrefixedLocalStorageKey } from '../../utils';
 
 export interface ChatProps {
   endPoint: string;
@@ -57,11 +57,11 @@ const Chat: (props: ChatProps) => JSX.Element = ({
         sendReferralParameter(referralParameter);
       }
 
-      const messageHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+      const messageHistoryLSKeyName = retrievePrefixedLocalStorageKey(
         localStorageHistory,
         'tockMessageHistory',
       );
-      const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+      const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKey(
         localStorageHistory,
         'tockQuickReplyHistory',
       );

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -5,6 +5,7 @@ import Container from '../Container';
 import Conversation from '../Conversation';
 import TockAccessibility from '../../TockAccessibility';
 import TockLocalStorage from 'TockLocalStorage';
+import { retrievePrefixedLocalStorageKeyName } from '../../utils';
 
 export interface ChatProps {
   endPoint: string;
@@ -55,18 +56,30 @@ const Chat: (props: ChatProps) => JSX.Element = ({
       if (referralParameter) {
         sendReferralParameter(referralParameter);
       }
+
+      const messageHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+        localStorageHistory,
+        'tockMessageHistory',
+      );
+      const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+        localStorageHistory,
+        'tockQuickReplyHistory',
+      );
+
       const history =
         localStorageHistory?.enable == true
-          ? window.localStorage.getItem('tockMessageHistory')
+          ? window.localStorage.getItem(messageHistoryLSKeyName)
           : undefined;
+
       if (messages.length === 0 && openingMessage && !history) {
         sendOpeningMessage(openingMessage);
       }
+
       if (history) {
         addHistory(
           JSON.parse(history),
           JSON.parse(
-            window.localStorage.getItem('tockQuickReplyHistory') || '[]',
+            window.localStorage.getItem(quickReplyHistoryLSKeyName) || '[]',
           ),
         );
       }

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -164,7 +164,9 @@ const ChatInput: (props: ChatInputProps) => JSX.Element = ({
           color={'white'}
           onClick={clearMessages}
           role="img"
-          aria-label={accessibility?.input?.clearButtonLabel || 'Clear messages'}
+          aria-label={
+            accessibility?.input?.clearButtonLabel || 'Clear messages'
+          }
           focusable="false"
         />
       </ClearIcon>

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Image from './Image';
 
-storiesOf('Image', module).add('Default', () => (
-  <Image
-    title="Card title"
-    url="https://avatars0.githubusercontent.com/u/48585267?s=200&v=4"
-  />
-)).add('With description', () => (
-  <Image
-    title="Card title"
-    url="https://avatars0.githubusercontent.com/u/48585267?s=200&v=4"
-    alternative="Image of the Tock icon"
-  />
-));
+storiesOf('Image', module)
+  .add('Default', () => (
+    <Image
+      title="Card title"
+      url="https://avatars0.githubusercontent.com/u/48585267?s=200&v=4"
+    />
+  ))
+  .add('With description', () => (
+    <Image
+      title="Card title"
+      url="https://avatars0.githubusercontent.com/u/48585267?s=200&v=4"
+      alternative="Image of the Tock icon"
+    />
+  ));

--- a/src/renderChat.tsx
+++ b/src/renderChat.tsx
@@ -24,7 +24,17 @@ export const renderChat: (
 ): void => {
   ReactDOM.render(
     <ThemeProvider theme={createTheme(theme)}>
-      <TockContext>
+      <TockContext
+        {...(storageAvailable('localStorage') && {
+          localStorageHistory: {
+            enable:
+              options.localStorage ||
+              options.localStorageHistory?.enable === true,
+            maxNumberMessages: options.localStorageHistory?.maxNumberMessages,
+            storagePrefix: options.localStorageHistory?.storagePrefix,
+          },
+        })}
+      >
         <Chat
           endPoint={endPoint}
           referralParameter={referralParameter}
@@ -40,6 +50,7 @@ export const renderChat: (
                 options.localStorage ||
                 options.localStorageHistory?.enable === true,
               maxNumberMessages: options.localStorageHistory?.maxNumberMessages,
+              storagePrefix: options.localStorageHistory?.storagePrefix,
             },
           })}
         />

--- a/src/useLocalTools.ts
+++ b/src/useLocalTools.ts
@@ -1,7 +1,7 @@
 import { Dispatch, useCallback } from 'react';
 import { TockAction, useTockDispatch } from './TockContext';
 import TockLocalStorage from './TockLocalStorage';
-import { retrievePrefixedLocalStorageKeyName } from './utils';
+import { retrievePrefixedLocalStorageKey } from './utils';
 
 export interface UseLocalTools {
   clearMessages: () => void;
@@ -13,11 +13,11 @@ const useLocalTools: (
   const dispatch: Dispatch<TockAction> = useTockDispatch();
   const clearMessages: () => void = useCallback(() => {
     if (localStorageHistory?.enable) {
-      const messageHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+      const messageHistoryLSKeyName = retrievePrefixedLocalStorageKey(
         localStorageHistory,
         'tockMessageHistory',
       );
-      const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+      const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKey(
         localStorageHistory,
         'tockQuickReplyHistory',
       );

--- a/src/useLocalTools.ts
+++ b/src/useLocalTools.ts
@@ -1,18 +1,28 @@
 import { Dispatch, useCallback } from 'react';
 import { TockAction, useTockDispatch } from './TockContext';
+import TockLocalStorage from './TockLocalStorage';
+import { retrievePrefixedLocalStorageKeyName } from './utils';
 
 export interface UseLocalTools {
   clearMessages: () => void;
 }
 
-const useLocalTools: (localStorage?: boolean) => UseLocalTools = (
-  localStorage,
-) => {
+const useLocalTools: (
+  localStorageHistory?: TockLocalStorage,
+) => UseLocalTools = (localStorageHistory) => {
   const dispatch: Dispatch<TockAction> = useTockDispatch();
   const clearMessages: () => void = useCallback(() => {
-    if (localStorage === true) {
-      window.localStorage.removeItem('tockMessageHistory');
-      window.localStorage.removeItem('tockQuickReplyHistory');
+    if (localStorageHistory?.enable) {
+      const messageHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+        localStorageHistory,
+        'tockMessageHistory',
+      );
+      const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+        localStorageHistory,
+        'tockQuickReplyHistory',
+      );
+      window.localStorage.removeItem(messageHistoryLSKeyName);
+      window.localStorage.removeItem(quickReplyHistoryLSKeyName);
     }
     dispatch({
       type: 'CLEAR_MESSAGES',

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -20,7 +20,7 @@ import {
 import { Sse } from './Sse';
 import useLocalTools, { UseLocalTools } from './useLocalTools';
 import TockLocalStorage from 'TockLocalStorage';
-import { retrievePrefixedLocalStorageKeyName } from './utils';
+import { retrievePrefixedLocalStorageKey } from './utils';
 
 export interface UseTock {
   messages: Message[];
@@ -127,7 +127,7 @@ const useTock: (
   const recordResponseToLocaleSession: (message: any) => void = (
     message: any,
   ) => {
-    const messageHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+    const messageHistoryLSKeyName = retrievePrefixedLocalStorageKey(
       localStorageHistory,
       'tockMessageHistory',
     );
@@ -162,7 +162,7 @@ const useTock: (
         quickReplies: quickReplies,
       });
       if (localStorageHistory?.enable ?? false) {
-        const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+        const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKey(
           localStorageHistory,
           'tockQuickReplyHistory',
         );

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -20,6 +20,7 @@ import {
 import { Sse } from './Sse';
 import useLocalTools, { UseLocalTools } from './useLocalTools';
 import TockLocalStorage from 'TockLocalStorage';
+import { retrievePrefixedLocalStorageKeyName } from './utils';
 
 export interface UseTock {
   messages: Message[];
@@ -107,9 +108,7 @@ const useTock: (
     sseInitializing,
   }: TockState = useTockState();
   const dispatch: Dispatch<TockAction> = useTockDispatch();
-  const { clearMessages }: UseLocalTools = useLocalTools(
-    localStorageHistory?.enable ?? false,
-  );
+  const { clearMessages }: UseLocalTools = useLocalTools(localStorageHistory);
 
   const startLoading: () => void = () => {
     dispatch({
@@ -128,7 +127,12 @@ const useTock: (
   const recordResponseToLocaleSession: (message: any) => void = (
     message: any,
   ) => {
-    let history: any = window.localStorage.getItem('tockMessageHistory');
+    const messageHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+      localStorageHistory,
+      'tockMessageHistory',
+    );
+
+    let history: any = window.localStorage.getItem(messageHistoryLSKeyName);
     const maxNumberMessages = localStorageHistory?.maxNumberMessages ?? 10;
     if (!history) {
       history = [];
@@ -139,7 +143,10 @@ const useTock: (
       history.splice(0, history.length - maxNumberMessages + 1);
     }
     history.push(message);
-    window.localStorage.setItem('tockMessageHistory', JSON.stringify(history));
+    window.localStorage.setItem(
+      messageHistoryLSKeyName,
+      JSON.stringify(history),
+    );
   };
 
   const handleBotResponse: (botResponse: any) => void = ({
@@ -155,8 +162,12 @@ const useTock: (
         quickReplies: quickReplies,
       });
       if (localStorageHistory?.enable ?? false) {
-        window.localStorage.setItem(
+        const quickReplyHistoryLSKeyName = retrievePrefixedLocalStorageKeyName(
+          localStorageHistory,
           'tockQuickReplyHistory',
+        );
+        window.localStorage.setItem(
+          quickReplyHistoryLSKeyName,
           JSON.stringify(quickReplies),
         );
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import TockLocalStorage from './TockLocalStorage';
 export const retrieveUserId: (
   localStorageHistory?: TockLocalStorage,
 ) => string = (localStorageHistory: TockLocalStorage) => {
-  const userIdLSKeyName = retrievePrefixedLocalStorageKeyName(
+  const userIdLSKeyName = retrievePrefixedLocalStorageKey(
     localStorageHistory,
     'userId',
   );
@@ -79,7 +79,7 @@ export const storageAvailable: (type: string) => boolean = (type: string) => {
  * @param key - key in local storage
  * @returns string - the local storage key name, possibly prefixed
  */
-export const retrievePrefixedLocalStorageKeyName: (
+export const retrievePrefixedLocalStorageKey: (
   localStorageHistory: TockLocalStorage | undefined,
   varName: string,
 ) => string = (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,21 @@
+import TockLocalStorage from './TockLocalStorage';
+
 /**
  * Retrieves persisted user id.
  */
-export const retrieveUserId: () => string = () =>
-  fromLocalStorage('userId', () => {
+export const retrieveUserId: (
+  localStorageHistory?: TockLocalStorage,
+) => string = (localStorageHistory: TockLocalStorage) => {
+  const userIdLSKeyName = retrievePrefixedLocalStorageKeyName(
+    localStorageHistory,
+    'userId',
+  );
+  return fromLocalStorage(userIdLSKeyName, () => {
     const date = Date.now().toString(36);
     const randomNumber = Math.random().toString(36).substr(2, 5);
     return (date + randomNumber).toUpperCase();
   });
+};
 
 /**
  * Retrieves and returns an object from the local storage if found.
@@ -62,4 +71,29 @@ export const storageAvailable: (type: string) => boolean = (type: string) => {
       storage.length !== 0
     );
   }
+};
+
+/**
+ * Retrieves a localstorage variable name, prefixed if a storagePrefix is defined.
+ * @param localStorageHistory - TockLocalStorage object if defined
+ * @param key - key in local storage
+ * @returns string - the local storage key name, possibly prefixed
+ */
+export const retrievePrefixedLocalStorageKeyName: (
+  localStorageHistory: TockLocalStorage | undefined,
+  varName: string,
+) => string = (
+  localStorageHistory: TockLocalStorage | undefined,
+  varName: string,
+) => {
+  const arr = [varName];
+
+  if (
+    localStorageHistory?.enable &&
+    localStorageHistory?.storagePrefix?.trim().length
+  ) {
+    arr.unshift(localStorageHistory.storagePrefix.trim());
+  }
+
+  return arr.join('_');
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,14 +86,12 @@ export const retrievePrefixedLocalStorageKey: (
   localStorageHistory: TockLocalStorage | undefined,
   varName: string,
 ) => {
-  const arr = [varName];
-
+  let key = varName;
   if (
     localStorageHistory?.enable &&
     localStorageHistory?.storagePrefix?.trim().length
   ) {
-    arr.unshift(localStorageHistory.storagePrefix.trim());
+    key = `${localStorageHistory.storagePrefix.trim()}_${key}`;
   }
-
-  return arr.join('_');
+  return key;
 };


### PR DESCRIPTION
To enable dialogs to be saved in local storage when the same domain exposes the React Kit for several different bots, this feature provides the optional parameter localStorageHistory.storagePrefix. The string supplied will be used to prefix the keys used by React Kit to save in local storage (e.g. with localStorageHistory.storagePrefix = "myprefix", userId => myprefix_userId, tockMessageHistory => myprefix_tockMessageHistory, etc.).