### PR TITLE
resolves #131: handle and expose metadata in messages and context 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,24 @@ renderChat(document.getElementById('chat'), '<TOCK_BOT_API_URL>', 'referralParam
 
 If the chat does not suit your needs you can also use the components separately.
 
+## Message Metadata
+
+*TOCK*'s backend supports sending metadata alongside messages. This metadata takes the form of key-value pairs of arbitrary strings.
+The `tock-react-kit` supports customization of the interface based on said metadata at two levels:
+
+### Chat metadata
+
+The metadata from the last processed response is made available globally in `TockContext`.
+This can be used to implement global effects on the chat interface, like showing status messages.
+This metadata is not persistent; it is therefore the responsibility of either the backend or a customized frontend to
+ensure data stays available if required.
+
+### Message metadata
+
+The metadata from each response is also attached to the corresponding messages.
+This metadata is persisted with the messages, including through page reloads if [local storage history](#local-storage-history) is enabled.
+At the current time, it is only available to custom React-based frontends that handle message rendering themselves.
+
 ## API Reference
 
 ### `renderChat(element, tockBotApiUrl, referralParameter, theme, options)`
@@ -248,18 +266,19 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 #### `Overrides`
 
-| Property name       | Type                   | Description                                                                      |
-|---------------------|------------------------|----------------------------------------------------------------------------------|
-| `card`              | `TockThemeCardStyle`   | Object for adding CSS styles on card component (see below)                       |
-| `chatInput`         | `TockThemeInputStyle?` | Object for adding CSS styles on chat input component (see below)                 |
-| `carouselContainer` | `string?`              | Additional CSS styles for carousel cards container (overrides base styles)       |
-| `carouselItem`      | `string?`              | Additional CSS styles for carousel cards container (overrides base styles)       |
-| `carouselArrow`     | `string?`              | Additional CSS styles for carousel scrolling arrows (overrides base styles)      |
-| `messageBot`        | `string?`              | Additional CSS styles for the bot's speech balloons (overrides base styles)      |
-| `messageUser`       | `string?`              | Additional CSS styles for the user's speech balloons (overrides base styles)     |
-| `quickReply`        | `string?`              | Additional CSS styles for the quick reply buttons (overrides base styles)        |
-| `chat`              | `string?`              | Additional CSS styles for the chat container (overrides base styles)             |
-| `quickReplyArrow`   | `string?`              | Additional CSS styles for quick replies scrolling arrows (overrides base styles) |
+| Property name       | Type                   | Description                                                                                                   |
+|---------------------|------------------------|---------------------------------------------------------------------------------------------------------------|
+| `card`              | `TockThemeCardStyle`   | Object for adding CSS styles on card component (see below)                                                    |
+| `chatInput`         | `TockThemeInputStyle?` | Object for adding CSS styles on chat input component (see below)                                              |
+| `carouselContainer` | `string?`              | Additional CSS styles for carousel cards container (overrides base styles)                                    |
+| `carouselItem`      | `string?`              | Additional CSS styles for carousel cards container (overrides base styles)                                    |
+| `carouselArrow`     | `string?`              | Additional CSS styles for carousel scrolling arrows (overrides base styles)                                   |
+| `messageGroup`      | `string?`              | Additional CSS styles for groups of speech balloons with the same author and metadata (overrides base styles) |
+| `messageBot`        | `string?`              | Additional CSS styles for the bot's speech balloons (overrides base styles)                                   |
+| `messageUser`       | `string?`              | Additional CSS styles for the user's speech balloons (overrides base styles)                                  |
+| `quickReply`        | `string?`              | Additional CSS styles for the quick reply buttons (overrides base styles)                                     |
+| `chat`              | `string?`              | Additional CSS styles for the chat container (overrides base styles)                                          |
+| `quickReplyArrow`   | `string?`              | Additional CSS styles for quick replies scrolling arrows (overrides base styles)                              |
 
 #### `TockThemeCardStyle`
 
@@ -283,16 +302,16 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 ### `TockOptions`
 
-| Property name                            | Type                                  | Description                                                      |
-|------------------------------------------|---------------------------------------|------------------------------------------------------------------|
-| `openingMessage`                         | `string?`                             | Initial message to send to the bot to trigger a welcome sequence |
-| `extraHeadersProvider`                   | `() => Promise<Record<string, string>`| Provider of extra HTTP headers for outgoing requests             |
-| `timeoutBetweenMessage`                  | `number?`                             | Timeout between message                                          |
-| `widgets`                                | `any?`                                | Custom display component                                         |
-| `disableSse`                             | `boolean?`                            | Disable SSE (not even trying)                                    |
-| `accessibility`                          | `TockAccessibility`                   | Object for overriding role and label accessibility attributes    |
-| ~~`localStorage`~~                       | ~~`boolean?`~~                        | Enable history local storage (@deprecated)                       |
-| `localStorageHistory`                    | `TockLocalStorage?`                   | Object for history local storage                                 |
+| Property name           | Type                                   | Description                                                      |
+|-------------------------|----------------------------------------|------------------------------------------------------------------|
+| `openingMessage`        | `string?`                              | Initial message to send to the bot to trigger a welcome sequence |
+| `extraHeadersProvider`  | `() => Promise<Record<string, string>` | Provider of extra HTTP headers for outgoing requests             |
+| `timeoutBetweenMessage` | `number?`                              | Timeout between message                                          |
+| `widgets`               | `any?`                                 | Custom display component                                         |
+| `disableSse`            | `boolean?`                             | Disable SSE (not even trying)                                    |
+| `accessibility`         | `TockAccessibility`                    | Object for overriding role and label accessibility attributes    |
+| ~~`localStorage`~~      | ~~`boolean?`~~                         | Enable history local storage (@deprecated)                       |
+| `localStorageHistory`   | `TockLocalStorage?`                    | Object for history local storage                                 |
 
 #### `TockAccessibility`
 
@@ -475,7 +494,7 @@ renderChat(
 #### SSE
 
 By default, the `tock-react-kit` tries to connect to the Bot through [Server-sent events](https://en.wikipedia.org/wiki/Server-sent_events).
-If an error occurs, it probably means the Bot does not accept SSE, and the `tock-react-kit` switches to classic requests.
+If an error occurs, it probably means the Bot's backend does not accept SSE, so the `tock-react-kit` switches to classic requests.
 
 The optional `disableSse`parameter makes it possible to disable SSE before even trying, possibly preventing a `404` error 
 from console (when the Bot does not accept SSE).

--- a/src/Sse.ts
+++ b/src/Sse.ts
@@ -1,64 +1,63 @@
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace Sse {
-  let sseIsEnabled = false;
-  let eventSource: EventSource;
-  let notInitialised: boolean;
+import { BotConnectorResponse } from './model/responses';
 
-  export function init(
-    tockEndPoint: string,
-    userId: string,
-    handleBotResponse: (botResponse: any) => void,
-    onSseStateChange: (state: number) => void,
-  ): Promise<void> {
-    return new Promise<void>((afterInit: () => void): void => {
-      if (typeof EventSource !== 'undefined' && tockEndPoint && !eventSource) {
-        notInitialised = true;
-        eventSource = new EventSource(tockEndPoint + '/sse?userid=' + userId);
-        setTimeout(() => onSseStateChange(eventSource.readyState));
-        eventSource.addEventListener(
-          'message',
-          (e: MessageEvent) => {
-            handleBotResponse(JSON.parse(e.data));
-          },
-          false,
-        );
-        eventSource.addEventListener(
-          'open',
-          () => {
+let sseIsEnabled = false;
+let eventSource: EventSource;
+let notInitialised: boolean;
+
+export function init(
+  tockEndPoint: string,
+  userId: string,
+  handleBotResponse: (botResponse: BotConnectorResponse) => void,
+  onSseStateChange: (state: number) => void,
+): Promise<void> {
+  return new Promise<void>((afterInit: () => void): void => {
+    if (typeof EventSource !== 'undefined' && tockEndPoint && !eventSource) {
+      notInitialised = true;
+      eventSource = new EventSource(tockEndPoint + '/sse?userid=' + userId);
+      setTimeout(() => onSseStateChange(eventSource.readyState));
+      eventSource.addEventListener(
+        'message',
+        (e: MessageEvent) => {
+          handleBotResponse(JSON.parse(e.data));
+        },
+        false,
+      );
+      eventSource.addEventListener(
+        'open',
+        () => {
+          onSseStateChange(eventSource.readyState);
+          sseIsEnabled = true;
+          if (notInitialised) {
+            afterInit();
+            notInitialised = false;
+          }
+        },
+        false,
+      );
+      eventSource.addEventListener(
+        'error',
+        () => {
+          if (eventSource.readyState == EventSource.CLOSED) {
             onSseStateChange(eventSource.readyState);
-            sseIsEnabled = true;
+            sseIsEnabled = false;
             if (notInitialised) {
               afterInit();
               notInitialised = false;
             }
-          },
-          false,
-        );
-        eventSource.addEventListener(
-          'error',
-          () => {
-            if (eventSource.readyState == EventSource.CLOSED) {
-              onSseStateChange(eventSource.readyState);
-              sseIsEnabled = false;
-              if (notInitialised) {
-                afterInit();
-                notInitialised = false;
-              }
-            }
-          },
-          false,
-        );
-      }
-    });
-  }
+          }
+        },
+        false,
+      );
+    }
+  });
+}
 
-  export function isEnable(): boolean {
-    return sseIsEnabled;
-  }
+export function isEnable(): boolean {
+  return sseIsEnabled;
+}
 
-  export function disable(): Promise<void> {
-    sseIsEnabled = false;
-    notInitialised = false;
-    return Promise.resolve();
-  }
+export function disable(): Promise<void> {
+  sseIsEnabled = false;
+  notInitialised = false;
+  return Promise.resolve();
 }

--- a/src/TockContext.tsx
+++ b/src/TockContext.tsx
@@ -1,18 +1,20 @@
 import React, {
+  Context,
+  createContext,
   Dispatch,
   ReactNode,
   Reducer,
-  useReducer,
-  createContext,
-  Context,
   useContext,
+  useReducer,
 } from 'react';
 import { retrieveUserId } from './utils';
+import { QuickReply } from './model/buttons';
+import { Message } from './model/messages';
 
-export const TockStateContext: Context<TockState | undefined> = createContext<
+const TockStateContext: Context<TockState | undefined> = createContext<
   TockState | undefined
 >(undefined);
-export const TockStateDispatch: Context<
+const TockStateDispatch: Context<
   Dispatch<TockAction> | undefined
 > = createContext<Dispatch<TockAction> | undefined>(undefined);
 
@@ -34,107 +36,9 @@ export const useTockDispatch: () => Dispatch<TockAction> = () => {
   return dispatch;
 };
 
-export class QuickReply {
-  label: string;
-  payload?: string;
-  nlpText?: string;
-  imageUrl?: string;
-
-  constructor(
-    label: string,
-    payload: string,
-    nlpText?: string,
-    imageUrl?: string,
-  ) {
-    this.label = label;
-    this.payload = payload;
-    this.nlpText = nlpText;
-    this.imageUrl = imageUrl;
-  }
-}
-
-export class PostBackButton {
-  label: string;
-  payload?: string;
-  imageUrl?: string;
-
-  constructor(label: string, payload: string, imageUrl?: string) {
-    this.label = label;
-    this.payload = payload;
-    this.imageUrl = imageUrl;
-  }
-}
-
-export class UrlButton {
-  label: string;
-  url: string;
-  imageUrl?: string;
-
-  constructor(label: string, url: string, imageUrl?: string) {
-    this.label = label;
-    this.url = url;
-    this.imageUrl = imageUrl;
-  }
-}
-
-export type Button = QuickReply | PostBackButton | UrlButton;
-
-export type Messages = Message | Card | Carousel | Widget | Image;
-
-export enum MessageType {
-  message = 'message',
-  card = 'card',
-  carousel = 'carousel',
-  widget = 'widget',
-  image = 'image',
-}
-
-export interface Message {
-  type: MessageType;
-  alreadyDisplayed?: boolean;
-}
-
-export interface TextMessage extends Message {
-  author: 'bot' | 'user';
-  message: string;
-  type: MessageType.message;
-  buttons?: Button[];
-}
-
-export interface Card extends Message {
-  imageUrl?: string;
-  imageAlternative?: string;
-  title: string;
-  subTitle?: string;
-  buttons?: Button[];
-  type: MessageType.card;
-}
-
-export interface Carousel extends Message {
-  cards: Card[];
-  type: MessageType.carousel;
-}
-
-export interface Widget extends Message {
-  widgetData: WidgetData;
-  type: MessageType.widget;
-}
-
-export interface WidgetData {
-  data: any;
-  type: string;
-}
-
-export interface Image extends Message {
-  url?: string;
-  title: string;
-  type: MessageType.image;
-  alternative?: string;
-}
-
 export interface TockState {
   quickReplies: QuickReply[];
-  messages: Messages[];
+  messages: Message[];
   userId: string;
   loading: boolean;
   sseInitializing: boolean;
@@ -148,12 +52,12 @@ export interface TockAction {
     | 'SET_SSE_INITIALIZING'
     | 'CLEAR_MESSAGES';
   quickReplies?: QuickReply[];
-  messages?: Messages[];
+  messages?: Message[];
   loading?: boolean;
   sseInitializing?: boolean;
 }
 
-export const tockReducer: Reducer<TockState, TockAction> = (
+const tockReducer: Reducer<TockState, TockAction> = (
   state: TockState,
   action: TockAction,
 ): TockState => {

--- a/src/TockContext.tsx
+++ b/src/TockContext.tsx
@@ -42,12 +42,14 @@ export interface TockState {
   userId: string;
   loading: boolean;
   sseInitializing: boolean;
+  metadata: Record<string, string>;
 }
 
 export interface TockAction {
   type:
     | 'SET_QUICKREPLIES'
     | 'ADD_MESSAGE'
+    | 'SET_METADATA'
     | 'SET_LOADING'
     | 'SET_SSE_INITIALIZING'
     | 'CLEAR_MESSAGES';
@@ -55,6 +57,7 @@ export interface TockAction {
   messages?: Message[];
   loading?: boolean;
   sseInitializing?: boolean;
+  metadata?: Record<string, string>;
 }
 
 const tockReducer: Reducer<TockState, TockAction> = (
@@ -102,6 +105,14 @@ const tockReducer: Reducer<TockState, TockAction> = (
         };
       }
       break;
+    case 'SET_METADATA':
+      if (action.metadata != undefined) {
+        return {
+          ...state,
+          metadata: action.metadata,
+        };
+      }
+      break;
     default:
       break;
   }
@@ -121,6 +132,7 @@ const TockContext: (props: { children?: ReactNode }) => JSX.Element = ({
       userId: retrieveUserId(),
       loading: false,
       sseInitializing: false,
+      metadata: {},
     },
   );
   return (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import { prop } from 'styled-tools';
 
-import { Button as ButtonData } from '../../TockContext';
+import { Button as ButtonData } from '../../model/buttons';
 import '../../styles/theme';
 
 export const CardOuter: StyledComponent<DetailedHTMLProps<

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { UrlButton } from '../../TockContext';
+import { UrlButton } from '../../model/buttons';
 import Carousel from './Carousel';
 import Card, { CardProps } from '../Card';
 

--- a/src/components/Conversation/Conversation.stories.tsx
+++ b/src/components/Conversation/Conversation.stories.tsx
@@ -4,7 +4,8 @@ import { useEffect } from 'react';
 import React from 'react';
 
 import useTock, { UseTock } from '../../useTock';
-import { MessageType, PostBackButton, UrlButton } from '../../TockContext';
+import { PostBackButton, UrlButton } from '../../model/buttons';
+import { MessageType } from '../../model/messages';
 import Product from '../widgets/ProductWidget/Product';
 import Conversation from './Conversation';
 

--- a/src/components/Conversation/Conversation.tsx
+++ b/src/components/Conversation/Conversation.tsx
@@ -1,5 +1,6 @@
 import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
 import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
 
 import DefaultWidget from '../widgets/DefaultWidget';
 import MessageBot from '../MessageBot';
@@ -12,22 +13,19 @@ import QuickReplyList from '../QuickReplyList';
 import InlineQuickReplyList from '../InlineQuickReplyList';
 import useMessageCounter from './hooks/useMessageCounter';
 import useScrollBehaviour from './hooks/useScrollBehaviour';
-import { useTheme } from '@emotion/react';
-import '../../styles/theme';
 import TockTheme from '../../styles/theme';
 
+import TockAccessibility from '../../TockAccessibility';
+import { Button, QuickReply } from '../../model/buttons';
 import type {
-  Button,
   Card as ICard,
   Carousel as ICarousel,
-  Message,
   Image as IImage,
+  Message,
   MessageType,
   TextMessage,
   Widget,
-  QuickReply as CQuickReply,
-} from 'TockContext';
-import TockAccessibility from 'TockAccessibility';
+} from '../../model/messages';
 
 const ConversationOuterContainer = styled.div`
   display: flex;
@@ -52,9 +50,10 @@ interface RenderOptions {
   onAction: (button: Button) => void;
 }
 
-const renderWidget = (message: Widget, options: RenderOptions) => {
-  const Widget = options?.widgets[message.widgetData.type] ?? DefaultWidget;
-  return <Widget {...message.widgetData.data} />;
+const renderWidget = (widget: Widget, options: RenderOptions) => {
+  const WidgetRenderer =
+    options.widgets?.[widget.widgetData.type] ?? DefaultWidget;
+  return <WidgetRenderer {...widget.widgetData.data} />;
 };
 
 const renderMessage = (message: TextMessage, options: RenderOptions) => {
@@ -105,7 +104,7 @@ const MESSAGE_RENDERER: {
 const makeRenderMessage = (
   options: RenderOptions,
   accessibility?: TockAccessibility,
-) => (message: Message | ICard | ICarousel | Widget, index: number) => {
+) => (message: Message, index: number) => {
   const render: Renderer = MESSAGE_RENDERER[message.type];
   if (!render) return null;
   return React.cloneElement(render(message, options, accessibility), {
@@ -121,7 +120,7 @@ type Props = DetailedHTMLProps<
   messageDelay: number;
   widgets?: { [id: string]: (props: unknown) => JSX.Element };
   loading?: boolean;
-  quickReplies: CQuickReply[];
+  quickReplies: QuickReply[];
   onAction: (button: Button) => void;
   onQuickReplyClick: (button: Button) => void;
   accessibility?: TockAccessibility;
@@ -164,21 +163,18 @@ const Conversation = ({
         </ConversationInnerContainer>
         {!loading &&
           displayableMessageCount === messages.length &&
-          theme.inlineQuickReplies !== true && (
-            <QuickReplyList
-              items={quickReplies}
-              onItemClick={onQuickReplyClick}
-            />
-          )}
-        {!loading &&
-          displayableMessageCount === messages.length &&
-          theme.inlineQuickReplies === true && (
+          (theme.inlineQuickReplies ? (
             <InlineQuickReplyList
               items={quickReplies}
               onItemClick={onQuickReplyClick}
               accessibility={accessibility}
             />
-          )}
+          ) : (
+            <QuickReplyList
+              items={quickReplies}
+              onItemClick={onQuickReplyClick}
+            />
+          ))}
       </ConversationOuterContainer>
     );
   } else {

--- a/src/components/Conversation/hooks/useMessageCounter.ts
+++ b/src/components/Conversation/hooks/useMessageCounter.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Message } from '../../../TockContext';
+import { Message } from '../../../model/messages';
 
 export default function useMessageCounter(
   messages: Message[],

--- a/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
+++ b/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
@@ -6,7 +6,7 @@ import { prop } from 'styled-tools';
 import { opacify } from 'polished';
 import '../../styles/theme';
 import TockTheme from '../../styles/theme';
-import { Button } from '../../TockContext';
+import { Button } from '../../model/buttons';
 import useCarouselQuickReply from './hooks/useCarouselQuickReply';
 import useArrowVisibility from '../Carousel/hooks/useArrowVisibility';
 import QuickReply from '../QuickReply/QuickReply';

--- a/src/components/MessageBot/MessageBot.stories.tsx
+++ b/src/components/MessageBot/MessageBot.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { MessageType } from '../../TockContext';
+import { MessageType } from '../../model/messages';
 import MessageBot from './MessageBot';
 
 const message = 'A bot message';

--- a/src/components/MessageBot/MessageBot.tsx
+++ b/src/components/MessageBot/MessageBot.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 // @ts-ignore
 import linkifyHtml from 'linkifyjs/html';
 import { prop } from 'styled-tools';
-import { Button, TextMessage } from '../../TockContext';
+import { Button } from '../../model/buttons';
+import { TextMessage } from '../../model/messages';
 import QuickReplyList from '../QuickReplyList';
 
 import '../../styles/theme';

--- a/src/components/QuickReply/QuickReply.tsx
+++ b/src/components/QuickReply/QuickReply.tsx
@@ -2,7 +2,7 @@ import styled, { StyledComponent } from '@emotion/styled';
 import React, { DetailedHTMLProps, HTMLAttributes, RefObject } from 'react';
 import { prop } from 'styled-tools';
 
-import { Button } from '../../TockContext';
+import { QuickReply as QuickReplyData } from '../../model/buttons';
 
 import QuickReplyImage from './QuickReplyImage';
 
@@ -40,7 +40,7 @@ type Props = DetailedHTMLProps<
   HTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
 > &
-  Button;
+  QuickReplyData;
 
 const QuickReply = React.forwardRef<HTMLButtonElement, Props>(
   ({ imageUrl, label, ...rest }: Props, ref: RefObject<HTMLButtonElement>) => (

--- a/src/components/QuickReplyList/QuickReplyList.tsx
+++ b/src/components/QuickReplyList/QuickReplyList.tsx
@@ -2,7 +2,7 @@ import React, { DetailedHTMLProps, HTMLAttributes, useCallback } from 'react';
 import styled, { StyledComponent } from '@emotion/styled';
 import { prop } from 'styled-tools';
 
-import { Button } from '../../TockContext';
+import { Button } from '../../model/buttons';
 import QuickReply from '../QuickReply/QuickReply';
 import '../../styles/theme';
 

--- a/src/components/widgets/ProductWidget/Product.ts
+++ b/src/components/widgets/ProductWidget/Product.ts
@@ -1,5 +1,7 @@
-export default interface Product {
+type Product = {
   name: string;
   description: string;
   price: number;
-}
+};
+
+export default Product;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,5 +22,14 @@ export { renderChat } from './renderChat';
 export { default as TockContext } from './TockContext';
 export { default as useTock } from './useTock';
 export { default as createTheme } from './styles/createTheme';
+export type {
+  Card as CardData,
+  Carousel as CarouselData,
+  Image as ImageData,
+  Message as MessageData,
+  TextMessage as TextMessageData,
+  Widget as WidgetData,
+  WidgetPayload,
+} from './model/messages';
 export type TockTheme = _TockTheme;
 export type TockOptions = _TockOptions;

--- a/src/model/buttons.ts
+++ b/src/model/buttons.ts
@@ -1,0 +1,44 @@
+export class QuickReply {
+  label: string;
+  payload?: string;
+  nlpText?: string;
+  imageUrl?: string;
+
+  constructor(
+    label: string,
+    payload: string,
+    nlpText?: string,
+    imageUrl?: string,
+  ) {
+    this.label = label;
+    this.payload = payload;
+    this.nlpText = nlpText;
+    this.imageUrl = imageUrl;
+  }
+}
+
+export class PostBackButton {
+  label: string;
+  payload?: string;
+  imageUrl?: string;
+
+  constructor(label: string, payload: string, imageUrl?: string) {
+    this.label = label;
+    this.payload = payload;
+    this.imageUrl = imageUrl;
+  }
+}
+
+export class UrlButton {
+  label: string;
+  url: string;
+  imageUrl?: string;
+
+  constructor(label: string, url: string, imageUrl?: string) {
+    this.label = label;
+    this.url = url;
+    this.imageUrl = imageUrl;
+  }
+}
+
+export type Button = QuickReply | PostBackButton | UrlButton;

--- a/src/model/messages.ts
+++ b/src/model/messages.ts
@@ -1,0 +1,55 @@
+import { Button } from './buttons';
+
+export type Message = TextMessage | Card | Carousel | Widget | Image;
+
+export enum MessageType {
+  message = 'message',
+  card = 'card',
+  carousel = 'carousel',
+  widget = 'widget',
+  image = 'image',
+}
+
+interface MessageBase {
+  type: MessageType;
+  alreadyDisplayed?: boolean;
+  metadata?: Record<string, string>;
+}
+
+export interface TextMessage extends MessageBase {
+  author: 'bot' | 'user';
+  message: string;
+  type: MessageType.message;
+  buttons?: Button[];
+}
+
+export interface Card extends MessageBase {
+  imageUrl?: string;
+  imageAlternative?: string;
+  title: string;
+  subTitle?: string;
+  buttons?: Button[];
+  type: MessageType.card;
+}
+
+export interface Carousel extends MessageBase {
+  cards: Card[];
+  type: MessageType.carousel;
+}
+
+export interface Widget extends MessageBase {
+  widgetData: WidgetPayload;
+  type: MessageType.widget;
+}
+
+export interface WidgetPayload {
+  data: Record<string, unknown>;
+  type: string;
+}
+
+export interface Image extends MessageBase {
+  url?: string;
+  title: string;
+  type: MessageType.image;
+  alternative?: string;
+}

--- a/src/model/responses.ts
+++ b/src/model/responses.ts
@@ -1,0 +1,73 @@
+/**
+ * Interface specified by [tock-bot-connector-web-model](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/WebConnectorResponse.kt)
+ */
+export interface BotConnectorResponse {
+  responses: BotConnectorMessage[];
+  metadata: Record<string, string>;
+}
+
+export interface BotConnectorMessage {
+  version: '1';
+
+  text?: string;
+  buttons?: BotConnectorButton[];
+  card?: BotConnectorCard;
+  carousel?: BotConnectorCarousel;
+  widget?: BotConnectorWidget;
+  image?: BotConnectorImage;
+  deepLink?: string;
+}
+
+export interface BotConnectorCard {
+  title?: string;
+  subTitle?: string;
+  file?: WebMediaFile;
+  buttons: BotConnectorButton[];
+}
+
+export interface WebMediaFile {
+  url: string;
+  name: string;
+  type: string;
+  description?: string;
+}
+
+export interface BotConnectorCarousel {
+  cards: BotConnectorCard[];
+}
+
+export interface BotConnectorWidget {
+  data: unknown;
+}
+
+export interface BotConnectorImage {
+  file: WebMediaFile;
+  title: string;
+}
+
+export type BotConnectorButton =
+  | BotConnectorQuickReply
+  | BotConnectorPostbackButton
+  | BotConnectorUrlButton;
+
+interface BotConnectorUrlButton {
+  type: 'web_url' | undefined;
+  title: string;
+  url: string;
+  imageUrl?: string;
+}
+
+interface BotConnectorPostbackButton {
+  type: 'postback';
+  title: string;
+  payload: string;
+  imageUrl: string;
+}
+
+interface BotConnectorQuickReply {
+  type: 'quick_reply';
+  title: string;
+  payload: string;
+  nlpText: string;
+  imageUrl: string;
+}

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -153,7 +153,13 @@ const useTock: (
 
   const handleBotResponse: (botResponse: BotConnectorResponse) => void = ({
     responses,
+    metadata,
   }) => {
+    dispatch({
+      type: 'SET_METADATA',
+      metadata: metadata || {},
+    });
+
     if (Array.isArray(responses) && responses.length > 0) {
       const lastMessage = responses[responses.length - 1];
       const quickReplies = (lastMessage.buttons || [])
@@ -197,6 +203,8 @@ const useTock: (
               type: MessageType.carousel,
             } as Carousel;
           }
+
+          message.metadata = metadata;
 
           if (localStorageHistory?.enable ?? false) {
             recordResponseToLocaleSession(message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,10 +14,10 @@ export const retrieveUserId: () => string = () =>
  * @param key - key in local storage
  * @param computeInitialValue - function to create an initial value if the object is not found
  */
-export const fromLocalStorage: (
+export const fromLocalStorage = <T>(
   key: string,
-  computeInitialValue: () => any,
-) => any = (key: string, computeInitialValue: () => any) => {
+  computeInitialValue: () => T,
+): T => {
   try {
     const item = window.localStorage.getItem(key);
     if (item) {
@@ -38,7 +38,7 @@ export const fromLocalStorage: (
  * @param type - Storage type
  * @returns true - if locale storage is available on the user's browser
  */
-export const storageAvailable: (type: string) => boolean = (type: string) => {
+export const storageAvailable: (type: string) => boolean = (type) => {
   let storage = undefined;
   try {
     storage = window[type];
@@ -59,7 +59,7 @@ export const storageAvailable: (type: string) => boolean = (type: string) => {
         // Firefox
         e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
       // acknowledge QuotaExceededError only if there's something already stored
-      storage.length !== 0
+      storage?.length !== 0
     );
   }
 };


### PR DESCRIPTION
## Metadata processing

This PR's main goal is to add metadata processing to the `tock-react-kit`.
The metadata is stored in `TockContext`, as transient information, and in individual message objects, as persistent information.

> [!NOTE]
> There is currently no way to use the metadata outside a React application. This could be added in the future.

I considered several ways of exposing the metadata to Emotion styling, notably through `MessageGroup` components which would allow styling groups of messages based on their metadata, but ultimately I believe a proper solution would need a more involved message rendering API.

## Cleanup

While implementing the new feature, I took the opportunity to clean up `TockContext` and improve typing.

Specifically:
- The `Sse` typescript namespace has been replaced with a regular javascript module.
- All `Message` data types have been moved away from `TockContext` into a dedicated `models/messages` file.
    - `Message` has been renamed to `TextMessage`, while `Messages` has been renamed to `Message`, as it represents a singular message object.
    - Message data types are now exported to third-parties as `*Data`.
        - `WidgetData` has been renamed to `WidgetPayload` for the sake of disambiguation.
- All `Button` data types have been moved away from `TockContext` into a dedicated `models/buttons` file.
- The bot connector response object now has a type definition in `models/responses`.

resolves #131 