### PR TITLE
fixes #134: type theme overrides as Emotion's Interpolation

### DIFF
--- a/src/styles/overrides.ts
+++ b/src/styles/overrides.ts
@@ -1,3 +1,4 @@
+import { Interpolation } from '@emotion/react';
 import TockThemeButtonStyle from './tockThemeButtonStyle';
 import TockThemeCardStyle from './tockThemeCardStyle';
 import TockThemeInputStyle from './tockThemeInputStyle';
@@ -6,13 +7,13 @@ export interface Overrides {
   buttons?: Partial<TockThemeButtonStyle>;
   card?: Partial<TockThemeCardStyle>;
   chatInput?: Partial<TockThemeInputStyle>;
-  carouselContainer?: string;
-  carouselItem?: string;
-  carouselArrow?: string;
-  messageBot?: string;
-  messageUser?: string;
-  quickReply?: string;
-  quickReplyImage?: string;
-  chat?: string;
-  quickReplyArrow?: string;
+  carouselContainer: Interpolation<unknown>;
+  carouselItem: Interpolation<unknown>;
+  carouselArrow: Interpolation<unknown>;
+  messageBot: Interpolation<unknown>;
+  messageUser: Interpolation<unknown>;
+  quickReply: Interpolation<unknown>;
+  quickReplyImage: Interpolation<unknown>;
+  chat: Interpolation<unknown>;
+  quickReplyArrow: Interpolation<unknown>;
 }

--- a/src/styles/tockThemeButtonStyle.ts
+++ b/src/styles/tockThemeButtonStyle.ts
@@ -1,8 +1,10 @@
+import { Interpolation } from '@emotion/react';
+
 interface TockThemeButtonStyle {
-  buttonContainer?: string;
-  buttonList?: string;
-  postbackButton?: string;
-  urlButton?: string;
+  buttonContainer: Interpolation<unknown>;
+  buttonList: Interpolation<unknown>;
+  postbackButton: Interpolation<unknown>;
+  urlButton: Interpolation<unknown>;
 }
 
 export default TockThemeButtonStyle;

--- a/src/styles/tockThemeCardStyle.ts
+++ b/src/styles/tockThemeCardStyle.ts
@@ -1,11 +1,13 @@
+import { Interpolation } from '@emotion/react';
+
 export interface TockThemeCardStyle {
-  cardContainer?: string;
-  cardTitle?: string;
-  cardSubTitle?: string;
-  cardImage?: string;
-  cardButton?: string;
-  buttonList?: string;
-  buttonContainer?: string;
+  cardContainer: Interpolation<unknown>;
+  cardTitle: Interpolation<unknown>;
+  cardSubTitle: Interpolation<unknown>;
+  cardImage: Interpolation<unknown>;
+  cardButton: Interpolation<unknown>;
+  buttonList: Interpolation<unknown>;
+  buttonContainer: Interpolation<unknown>;
 }
 
 export default TockThemeCardStyle;

--- a/src/styles/tockThemeInputStyle.ts
+++ b/src/styles/tockThemeInputStyle.ts
@@ -1,7 +1,9 @@
+import { Interpolation } from '@emotion/react';
+
 export interface TockThemeInputStyle {
-  container?: string;
-  input?: string;
-  icon?: string;
+  container: Interpolation<unknown>;
+  input: Interpolation<unknown>;
+  icon: Interpolation<unknown>;
 }
 
 export default TockThemeInputStyle;


### PR DESCRIPTION
This PR simply replaces the type of overrides with `Interpolation` from Emotion's React module. This lets consumers use the full range of Emotion styling practices, at the cost of intertwining `tock-react-kit`'s API with Emotion's.

> [!NOTE]
> `Interpolation` takes a type parameter corresponding to the React properties of the styled components. This could later be used to allow more advanced styling, but for now I figured the specific type of our components' properties was more of an implementation detail (hence the `unknown` typing).

fixes #134 