### PR TITLE
fix #141: handle UrlButton#target 

### DIFF
--- a/src/components/buttons/UrlButton/UrlButton.stories.tsx
+++ b/src/components/buttons/UrlButton/UrlButton.stories.tsx
@@ -25,3 +25,12 @@ export const WithImage: Story = {
     imageUrl: 'https://doc.tock.ai/tock/assets/images/logo.svg',
   },
 };
+
+export const WithTarget: Story = {
+  name: 'URL Button with _self target',
+  args: {
+    label: 'TOCK',
+    url: 'https://doc.tock.ai',
+    target: '_self',
+  },
+};

--- a/src/components/buttons/UrlButton/UrlButton.tsx
+++ b/src/components/buttons/UrlButton/UrlButton.tsx
@@ -25,6 +25,7 @@ type Props = {
   customStyle?: Interpolation<unknown>;
   imageUrl?: string;
   label: string;
+  target?: string;
   url: string;
 };
 
@@ -32,9 +33,10 @@ export const UrlButton: (props: Props) => JSX.Element = ({
   url,
   imageUrl,
   label,
+  target = '_blank',
   ...rest
 }: Props) => (
-  <UrlButtonAnchor href={url} target="_blank" {...rest}>
+  <UrlButtonAnchor href={url} target={target} {...rest}>
     {imageUrl && <QuickReplyImage src={imageUrl} />}
     {label}
   </UrlButtonAnchor>

--- a/src/model/buttons.ts
+++ b/src/model/buttons.ts
@@ -33,11 +33,13 @@ export class UrlButton {
   label: string;
   url: string;
   imageUrl?: string;
+  target?: string;
 
-  constructor(label: string, url: string, imageUrl?: string) {
+  constructor(label: string, url: string, imageUrl?: string, target?: string) {
     this.label = label;
     this.url = url;
     this.imageUrl = imageUrl;
+    this.target = target;
   }
 }
 

--- a/src/model/responses.ts
+++ b/src/model/responses.ts
@@ -55,6 +55,7 @@ interface BotConnectorUrlButton {
   title: string;
   url: string;
   imageUrl?: string;
+  target?: string;
 }
 
 interface BotConnectorPostbackButton {

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -61,7 +61,12 @@ export interface UseTock {
 
 function mapButton(button: BotConnectorButton): Button {
   if (button.type === 'web_url') {
-    return new UrlButton(button.title, button.url, button.imageUrl);
+    return new UrlButton(
+      button.title,
+      button.url,
+      button.imageUrl,
+      button.target,
+    );
   } else if (button.type === 'postback') {
     return new PostBackButton(button.title, button.payload, button.imageUrl);
   } else if (button.type === 'quick_reply') {
@@ -72,7 +77,12 @@ function mapButton(button: BotConnectorButton): Button {
       button.imageUrl,
     );
   } else {
-    return new UrlButton(button.title, button.url, button.imageUrl);
+    return new UrlButton(
+      button.title,
+      button.url,
+      button.imageUrl,
+      button.target,
+    );
   }
 }
 


### PR DESCRIPTION
This PR is based on #133 and #140, as it depends on respectively the refactored response handling, and the new button types.

Relevant commit: f2aecea5ab317017fd128478f76a0a65c3d1d37c

fixes #141 