### PR TITLE
fix #154: replace opacify with vanilla CSS function

### DIFF
--- a/.storybook/decorators/ThemeDecorator.tsx
+++ b/.storybook/decorators/ThemeDecorator.tsx
@@ -17,7 +17,7 @@ export const palettes: Record<string, Partial<Palette>> = {
         },
         background: {
             user: '#e58e26',
-            bot: '#b71540',
+            bot: 'var(--test, #b71540)',
             card: '#0c2461',
             input: '#0a3d62',
             inputDisabled: '#079992',

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -55,9 +55,13 @@ const Previous: StyledComponent<DetailedHTMLProps<
   padding: 1em;
   background: color-mix(
     in srgb,
-    ${(props) => props.theme.palette.background.bot} 20%,
+    ${(props) => props.theme.palette.background.bot} 15%,
     transparent
   );
+  backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   width: 4em;
   height: 4em;
@@ -92,9 +96,13 @@ const Next: StyledComponent<DetailedHTMLProps<
   padding: 1em;
   background: color-mix(
     in srgb,
-    ${(props) => props.theme.palette.background.bot} 20%,
+    ${(props) => props.theme.palette.background.bot} 15%,
     transparent
   );
+  backdrop-filter: blur(3px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   width: 4em;
   height: 4em;

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -3,7 +3,6 @@ import { ArrowLeftCircle, ArrowRightCircle } from 'react-feather';
 import { useTheme } from '@emotion/react';
 import styled, { StyledComponent } from '@emotion/styled';
 import { prop } from 'styled-tools';
-import { opacify } from 'polished';
 import useCarousel from './hooks/useCarousel';
 import useArrowVisibility from './hooks/useArrowVisibility';
 import TockAccessibility from 'TockAccessibility';
@@ -54,7 +53,11 @@ const Previous: StyledComponent<DetailedHTMLProps<
   top: 0;
   bottom: 0;
   padding: 1em;
-  background: ${(props) => opacify(-0.8, props.theme.palette.background.bot)};
+  background: color-mix(
+    in srgb,
+    ${(props) => props.theme.palette.background.bot} 20%,
+    transparent
+  );
   border: none;
   width: 4em;
   height: 4em;
@@ -87,7 +90,11 @@ const Next: StyledComponent<DetailedHTMLProps<
   top: 0;
   bottom: 0;
   padding: 1em;
-  background: ${(props) => opacify(-0.8, props.theme.palette.background.bot)};
+  background: color-mix(
+    in srgb,
+    ${(props) => props.theme.palette.background.bot} 20%,
+    transparent
+  );
   border: none;
   width: 4em;
   height: 4em;

--- a/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
+++ b/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
@@ -3,7 +3,6 @@ import { ArrowLeftCircle, ArrowRightCircle } from 'react-feather';
 import { useTheme } from '@emotion/react';
 import styled, { StyledComponent } from '@emotion/styled';
 import { prop } from 'styled-tools';
-import { opacify } from 'polished';
 import '../../styles/theme';
 import TockTheme from '../../styles/theme';
 import { Button } from '../../model/buttons';
@@ -45,7 +44,11 @@ const Previous: StyledComponent<DetailedHTMLProps<
   top: 0;
   bottom: 0;
   padding: 1em;
-  background: ${(props) => opacify(-0.8, props.theme.palette.background.bot)};
+  background: color-mix(
+    in srgb,
+    ${(props) => props.theme.palette.background.bot} 20%,
+    transparent
+  );
   border: none;
   width: 3em;
   height: 3em;
@@ -78,7 +81,11 @@ const Next: StyledComponent<DetailedHTMLProps<
   top: 0;
   bottom: 0;
   padding: 1em;
-  background: ${(props) => opacify(-0.8, props.theme.palette.background.bot)};
+  background: color-mix(
+    in srgb,
+    ${(props) => props.theme.palette.background.bot} 20%,
+    transparent
+  );
   border: none;
   width: 3em;
   height: 3em;

--- a/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
+++ b/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
@@ -46,9 +46,13 @@ const Previous: StyledComponent<DetailedHTMLProps<
   padding: 1em;
   background: color-mix(
     in srgb,
-    ${(props) => props.theme.palette.background.bot} 20%,
+    ${(props) => props.theme.palette.background.bot} 10%,
     transparent
   );
+  backdrop-filter: blur(1px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   width: 3em;
   height: 3em;
@@ -83,9 +87,13 @@ const Next: StyledComponent<DetailedHTMLProps<
   padding: 1em;
   background: color-mix(
     in srgb,
-    ${(props) => props.theme.palette.background.bot} 20%,
+    ${(props) => props.theme.palette.background.bot} 10%,
     transparent
   );
+  backdrop-filter: blur(1px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   width: 3em;
   height: 3em;


### PR DESCRIPTION
Fixes #154 by using CSS [`color-mix`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) instead of `opacify`. 

The [support table from CanIUse](https://caniuse.com/?search=color-mix) says 85% of users have a compatible browser, which I believe should be enough for a minor feature like carousel arrows (if the function is not supported, the background will simply be transparent)

I also took the opportunity to fix the alignment of the icon inside the button (center it properly), and add a little [backdrop blur](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter).

Final look:

![image](https://github.com/theopenconversationkit/tock-react-kit/assets/79657435/f27f19da-075d-4687-9441-7a99ec79b645)
