### PR TITLE
Resolves #163: add custom renderers config for images and texts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,8 +38,10 @@ module.exports = {
         },
       },
     ],
-    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { ignoreRestSiblings: true },
+    ],
   },
   plugins: ['@emotion'],
 };

--- a/README.md
+++ b/README.md
@@ -166,14 +166,15 @@ If the chat does not suit your needs, there are two main ways to customize the i
 
 ### Configure custom renderers
 
-Custom rendering can currently be defined for text and images. Here are some examples of what this enables:
+Custom rendering can currently be defined for text, images, and buttons. Here are some examples of what this enables:
 
 - processing custom markup in the text of any component
 - stripping harmful HTML tags and attributes when the backend is untrustworthy
-- dynamically decorating text messages
+- dynamically decorating text messages and buttons
 - automatically embedding SVG images into the DOM
 - implementing fallback behavior when an image fails to load
 - using [metadata](#message-metadata) sent by the server to set image properties like width and height
+- setting up redirects for links
 
 See the [`TockSettings`](#renderersettings) API reference for the details of available renderers.
 
@@ -346,10 +347,24 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 #### `RendererSettings`
 
-| Property name    | Type                     | Description                                                                   |
-|------------------|--------------------------|-------------------------------------------------------------------------------|
-| `imageRenderers` | `ImageRendererSettings?` | Configuration of renderers for dynamic images displayed in the chat interface |
-| `textRenderers`  | `TextRendererSettings?`  | Configuration of renderers for dynamic text displayed in the chat interface   |
+| Property name     | Type               | Description                                                                   |
+|-------------------|--------------------|-------------------------------------------------------------------------------|
+| `buttonRenderers` | `ButtonRenderers?` | Configuration of renderers for buttons displayed in the chat interface        |
+| `imageRenderers`  | `ImageRenderers?`  | Configuration of renderers for dynamic images displayed in the chat interface |
+| `textRenderers`   | `TextRenderers?`   | Configuration of renderers for dynamic text displayed in the chat interface   |
+
+#### `ButtonRendererSettings`
+
+Button renderers all implement some specialization of the `ButtonRenderer` interface.
+They are tasked with rendering a graphical component using button-specific data, a class name, and other generic HTML attributes.
+The passed in class name provides the default style for the rendered component, as well as applicable [overrides](#overrides).
+
+| Property name | Type                        | Description                                                                                          |
+|---------------|-----------------------------|------------------------------------------------------------------------------------------------------|
+| `default`     | `ButtonRenderer`            | The fallback renderer. By default, renders a single `button` component using the provided properties |
+| `url`         | `UrlButtonRenderer`         | Renders an `UrlButton`. By default, renders a single `a` component using the provided properties     |
+| `postback`    | `PostBackButtonRenderer?`   | Renders a `PostBackButton`                                                                           |
+| `quickReply`  | `QuickReplyButtonRenderer?` | Renders a `QuickReply`                                                                               |
 
 #### `ImageRendererSettings`
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ Your bundler must support ESM modules, which is the case for Webpack, Rollup and
 import { ThemeProvider } from "@emotion/react";
 import { TockContext, Chat, createTheme } from 'tock-react-kit';
 
-<TockContext settings={ /* ... */ }>
+<TockContext settings={{
+    endPoint: "<TOCK_BOT_API_URL>",
+}}>
     <ThemeProvider theme={createTheme({ /* ... */})}>
         <Chat
-            endPoint="<TOCK_BOT_API_URL>"
             /* The following parameters are optional */
             referralParameter="referralParameter"
             // also accepts all properties from TockOptions, like:
@@ -335,6 +336,7 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 | Property name  | Type                    | Description                                          |
 |----------------|-------------------------|------------------------------------------------------|
+| `endPoint`     | `string`                | URL for the bot's web connector endpoint             |
 | `locale`       | `string?`               | Optional user language, as an *RFC 5646* code        |
 | `localStorage` | `LocalStorageSettings?` | Configuration for use of localStorage by the library |
 | `renderers`    | `RendererSettings?`     | Configuration for custom image and text renderers    |

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -147,13 +147,17 @@ const Card = forwardRef<HTMLLIElement, CardProps>(function cardRender(
     // having the default index-based key is fine since we do not reorder buttons
     <li key={index}>
       {'url' in button ? (
-        <UrlButton customStyle={urlButtonStyle} {...button} />
+        <UrlButton
+          buttonData={button}
+          customStyle={urlButtonStyle}
+          {...(isHidden && { tabIndex: -1 })}
+        />
       ) : (
         <PostBackButton
+          buttonData={button}
           customStyle={postBackButtonStyle}
           onClick={onAction.bind(null, button)}
           onKeyPress={onAction.bind(null, button)}
-          {...button}
           {...(isHidden && { tabIndex: -1 })}
         />
       )}

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -8,7 +8,7 @@ import TockLocalStorage from 'TockLocalStorage';
 import PostInitContext from '../../PostInitContext';
 
 export interface ChatProps {
-  endPoint: string;
+  endPoint?: string;
   referralParameter?: string;
   timeoutBetweenMessage?: number;
   /** A callback that will be executed once the chat is able to send and receive messages */

--- a/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
+++ b/src/components/InlineQuickReplyList/InlineQuickReplyList.tsx
@@ -156,8 +156,8 @@ const InlineQuickReplyList = ({
         {items.map((child, index) => (
           <QuickReply
             key={`${child.label}-${index}`}
+            buttonData={child}
             onClick={onItemClick.bind(null, child)}
-            {...child}
             ref={ref.items[index]}
           />
         ))}

--- a/src/components/QuickReply/QuickReply.tsx
+++ b/src/components/QuickReply/QuickReply.tsx
@@ -5,7 +5,10 @@ import React, { DetailedHTMLProps, HTMLAttributes, RefObject } from 'react';
 import { QuickReply as QuickReplyData } from '../../model/buttons';
 
 import QuickReplyImage from './QuickReplyImage';
-import { useTextRenderer } from '../../settings/RendererSettings';
+import {
+  useButtonRenderer,
+  useTextRenderer,
+} from '../../settings/RendererSettings';
 
 const QuickReplyButtonContainer = styled.li`
   list-style: none;
@@ -46,25 +49,29 @@ const qrButtonCss: Interpolation<Theme> = [
   (theme) => theme.overrides?.quickReply,
 ];
 
-type Props = DetailedHTMLProps<
-  HTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
-> &
-  QuickReplyData;
+interface Props
+  extends DetailedHTMLProps<
+    HTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  > {
+  buttonData: QuickReplyData;
+}
 
 const QuickReply = React.forwardRef<HTMLButtonElement, Props>(
-  (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { imageUrl, label, payload, nlpText, ...rest }: Props,
-    ref: RefObject<HTMLButtonElement>,
-  ) => {
+  ({ buttonData, ...rest }: Props, ref: RefObject<HTMLButtonElement>) => {
     const TextRenderer = useTextRenderer('default');
+    const ButtonRenderer = useButtonRenderer('quickReply');
     return (
       <QuickReplyButtonContainer>
-        <button ref={ref} css={qrButtonCss} {...rest}>
-          {imageUrl && <QuickReplyImage src={imageUrl} />}
-          <TextRenderer text={label} />
-        </button>
+        <ButtonRenderer
+          buttonData={buttonData}
+          ref={ref}
+          css={qrButtonCss}
+          {...rest}
+        >
+          {buttonData.imageUrl && <QuickReplyImage src={buttonData.imageUrl} />}
+          <TextRenderer text={buttonData.label} />
+        </ButtonRenderer>
       </QuickReplyButtonContainer>
     );
   },

--- a/src/components/QuickReplyList/QuickReplyList.tsx
+++ b/src/components/QuickReplyList/QuickReplyList.tsx
@@ -50,8 +50,8 @@ const QuickReplyList: (props: Props) => JSX.Element = ({
     (item: Button, index: number) => (
       <QuickReply
         key={`${item.label}-${index}`}
+        buttonData={item}
         onClick={onItemClick.bind(null, item)}
-        {...item}
       />
     ),
     [onItemClick],

--- a/src/components/buttons/ButtonList/ButtonList.tsx
+++ b/src/components/buttons/ButtonList/ButtonList.tsx
@@ -38,9 +38,12 @@ export const ButtonList: (props: Props) => JSX.Element = ({
     // having the default index-based key is fine since we do not reorder buttons
     <li key={index}>
       {'url' in item ? (
-        <UrlButton {...item}></UrlButton>
+        <UrlButton buttonData={item} />
       ) : (
-        <PostBackButton onClick={onItemClick.bind(null, item)} {...item} />
+        <PostBackButton
+          buttonData={item}
+          onClick={onItemClick.bind(null, item)}
+        />
       )}
     </li>
   );

--- a/src/components/buttons/PostBackButton/PostBackButton.stories.tsx
+++ b/src/components/buttons/PostBackButton/PostBackButton.stories.tsx
@@ -12,14 +12,18 @@ type Story = StoryObj<typeof PostBackButton>;
 export const SimplePostback: Story = {
   name: 'PostBack Button',
   args: {
-    label: 'Help',
+    buttonData: {
+      label: 'Help',
+    },
   },
 };
 
 export const WithImage: Story = {
   name: 'PostBack Button with image',
   args: {
-    label: 'Help',
-    imageUrl: 'https://doc.tock.ai/tock/assets/images/logo.svg',
+    buttonData: {
+      label: 'Help',
+      imageUrl: 'https://doc.tock.ai/tock/assets/images/logo.svg',
+    },
   },
 };

--- a/src/components/buttons/PostBackButton/PostBackButton.tsx
+++ b/src/components/buttons/PostBackButton/PostBackButton.tsx
@@ -1,9 +1,13 @@
 import { quickReplyStyle } from '../../QuickReply/QuickReply';
 import { Interpolation, Theme } from '@emotion/react';
 import { baseButtonStyle } from '../../QuickReply';
-import { DetailedHTMLProps, HTMLAttributes } from 'react';
+import { DetailedHTMLProps, HTMLAttributes, JSX } from 'react';
 import QuickReplyImage from '../../QuickReply/QuickReplyImage';
-import { useTextRenderer } from '../../../settings/RendererSettings';
+import {
+  useButtonRenderer,
+  useTextRenderer,
+} from '../../../settings/RendererSettings';
+import { PostBackButtonData } from '../../../index';
 
 const postBackButtonCss: Interpolation<Theme> = [
   baseButtonStyle,
@@ -15,29 +19,29 @@ const postBackButtonCss: Interpolation<Theme> = [
   ],
 ];
 
-type Props = DetailedHTMLProps<
-  HTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
-> & {
+interface Props
+  extends DetailedHTMLProps<
+    HTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  > {
+  buttonData: PostBackButtonData;
   customStyle?: Interpolation<unknown>;
-  imageUrl?: string;
-  label: string;
   tabIndex?: 0 | -1;
-};
+}
 
 export const PostBackButton = ({
-  imageUrl,
-  label,
+  buttonData,
   customStyle,
   ...rest
 }: Props): JSX.Element => {
   // Allow custom override for the Card's button styling
   const css = customStyle ? [baseButtonStyle, customStyle] : postBackButtonCss;
   const TextRenderer = useTextRenderer('default');
+  const ButtonRenderer = useButtonRenderer('postback');
   return (
-    <button css={css} {...rest}>
-      {imageUrl && <QuickReplyImage src={imageUrl} />}
-      <TextRenderer text={label} />
-    </button>
+    <ButtonRenderer buttonData={buttonData} css={css} {...rest}>
+      {buttonData.imageUrl && <QuickReplyImage src={buttonData.imageUrl} />}
+      <TextRenderer text={buttonData.label} />
+    </ButtonRenderer>
   );
 };

--- a/src/components/buttons/UrlButton/UrlButton.stories.tsx
+++ b/src/components/buttons/UrlButton/UrlButton.stories.tsx
@@ -12,25 +12,31 @@ type Story = StoryObj<typeof UrlButton>;
 export const SimpleUrl: Story = {
   name: 'URL Button',
   args: {
-    label: 'TOCK',
-    url: 'https://doc.tock.ai',
+    buttonData: {
+      label: 'TOCK',
+      url: 'https://doc.tock.ai',
+    },
   },
 };
 
 export const WithImage: Story = {
   name: 'URL Button with image',
   args: {
-    label: 'TOCK',
-    url: 'https://doc.tock.ai',
-    imageUrl: 'https://doc.tock.ai/tock/assets/images/logo.svg',
+    buttonData: {
+      label: 'TOCK',
+      url: 'https://doc.tock.ai',
+      imageUrl: 'https://doc.tock.ai/tock/assets/images/logo.svg',
+    },
   },
 };
 
 export const WithTarget: Story = {
   name: 'URL Button with _self target',
   args: {
-    label: 'TOCK',
-    url: 'https://doc.tock.ai',
-    target: '_self',
+    buttonData: {
+      label: 'TOCK',
+      url: 'https://doc.tock.ai',
+      target: '_self',
+    },
   },
 };

--- a/src/components/buttons/UrlButton/UrlButton.tsx
+++ b/src/components/buttons/UrlButton/UrlButton.tsx
@@ -2,14 +2,15 @@ import { quickReplyStyle } from '../../QuickReply/QuickReply';
 import { css, Interpolation, Theme } from '@emotion/react';
 import { baseButtonStyle } from '../../QuickReply';
 import QuickReplyImage from '../../QuickReply/QuickReplyImage';
-import { useTextRenderer } from '../../../settings/RendererSettings';
+import {
+  useButtonRenderer,
+  useTextRenderer,
+} from '../../../settings/RendererSettings';
+import { UrlButton as UrlButtonData } from '../../../model/buttons';
 
 type Props = {
   customStyle?: Interpolation<unknown>;
-  imageUrl?: string;
-  label: string;
-  target?: string;
-  url: string;
+  buttonData: UrlButtonData;
   tabIndex?: 0 | -1;
 };
 
@@ -29,10 +30,7 @@ const defaultUrlButtonCss: Interpolation<Theme> = [
 ];
 
 export const UrlButton: (props: Props) => JSX.Element = ({
-  url,
-  imageUrl,
-  label,
-  target = '_blank',
+  buttonData,
   customStyle,
   tabIndex,
 }: Props) => {
@@ -40,10 +38,17 @@ export const UrlButton: (props: Props) => JSX.Element = ({
     ? [baseUrlButtonCss, customStyle]
     : defaultUrlButtonCss;
   const TextRenderer = useTextRenderer('default');
+  const ButtonRenderer = useButtonRenderer('url');
   return (
-    <a href={url} target={target} css={css} tabIndex={tabIndex}>
-      {imageUrl && <QuickReplyImage src={imageUrl} />}
-      <TextRenderer text={label} />
-    </a>
+    <ButtonRenderer
+      buttonData={buttonData}
+      href={buttonData.url}
+      target={buttonData.target ?? '_blank'}
+      css={css}
+      tabIndex={tabIndex}
+    >
+      {buttonData.imageUrl && <QuickReplyImage src={buttonData.imageUrl} />}
+      <TextRenderer text={buttonData.label} />
+    </ButtonRenderer>
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,12 @@ export { default as createTheme } from './styles/createTheme';
 export { useMessageMetadata, MessageMetadataContext } from './MessageMetadata';
 export { useImageRenderer, useTextRenderer } from './settings/RendererSettings';
 export type {
+  Button as ButtonData,
+  PostBackButton as PostBackButtonData,
+  UrlButton as UrlButtonData,
+  QuickReply as QuickReplyData,
+} from './model/buttons';
+export type {
   Card as CardData,
   Carousel as CarouselData,
   Image as ImageData,
@@ -47,3 +53,10 @@ export type {
   TextRenderers,
   ImageRenderers,
 } from './settings/RendererSettings';
+export type {
+  ButtonRenderers,
+  ButtonRenderer,
+  BaseButtonRendererProps,
+  UrlButtonRenderer,
+  UrlButtonRendererProps,
+} from './settings/ButtonRenderers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export { default as MessageUser } from './components/MessageUser';
 export { default as QuickReply } from './components/QuickReply';
 export { default as QuickReplyList } from './components/QuickReplyList';
 export { renderChat } from './renderChat';
-export { default as TockContext } from './TockContext';
+export { default as TockContext, useTockSettings } from './TockContext';
 export { default as useTock } from './useTock';
 export { default as createTheme } from './styles/createTheme';
 export { useMessageMetadata, MessageMetadataContext } from './MessageMetadata';

--- a/src/renderChat.tsx
+++ b/src/renderChat.tsx
@@ -28,18 +28,16 @@ export const renderChat: (
     );
   }
 
-  const settings: PartialDeep<TockSettings> = {};
+  const settings: PartialDeep<TockSettings> = {
+    endPoint,
+  };
   if (localStorage) settings.localStorage = localStorage;
   if (locale) settings.locale = locale;
 
   createRoot(container).render(
     <ThemeProvider theme={createTheme(theme)}>
       <TockContext settings={settings}>
-        <Chat
-          endPoint={endPoint}
-          referralParameter={referralParameter}
-          {...options}
-        />
+        <Chat referralParameter={referralParameter} {...options} />
       </TockContext>
     </ThemeProvider>,
   );

--- a/src/settings/ButtonRenderers.ts
+++ b/src/settings/ButtonRenderers.ts
@@ -1,0 +1,54 @@
+import {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ComponentType,
+  DetailedHTMLProps,
+  ReactNode,
+} from 'react';
+import {
+  Button as ButtonData,
+  PostBackButton as PostBackButtonData,
+  QuickReply as QuickReplyData,
+  UrlButton as UrlButtonData,
+  UrlButton,
+} from '../model/buttons';
+
+import { RendererRegistry } from './RendererRegistry';
+
+export interface BaseButtonRendererProps<B extends ButtonData> {
+  buttonData: B;
+  /**
+   * The default content for the button, based on the {@link #buttonData}
+   */
+  children: ReactNode;
+}
+
+export type ButtonRendererProps<B extends ButtonData> = DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> &
+  BaseButtonRendererProps<B>;
+
+export type ButtonRenderer<
+  B extends ButtonData,
+  P extends BaseButtonRendererProps<B> = ButtonRendererProps<B>,
+> = ComponentType<P>;
+
+export type UrlButtonRendererProps = BaseButtonRendererProps<UrlButton> &
+  DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+
+export type UrlButtonRenderer = ButtonRenderer<
+  UrlButtonData,
+  UrlButtonRendererProps
+>;
+
+export type PostBackButtonRenderer = ButtonRenderer<PostBackButtonData>;
+
+export type QuickReplyButtonRenderer = ButtonRenderer<QuickReplyData>;
+
+export interface ButtonRenderers extends RendererRegistry {
+  default: ButtonRenderer<ButtonData>;
+  url: UrlButtonRenderer;
+  postback?: PostBackButtonRenderer;
+  quickReply?: QuickReplyButtonRenderer;
+}

--- a/src/settings/RendererRegistry.tsx
+++ b/src/settings/RendererRegistry.tsx
@@ -1,0 +1,5 @@
+import { ComponentType } from 'react';
+
+export interface RendererRegistry {
+  default: NonNullable<ComponentType<unknown>>;
+}

--- a/src/settings/RendererSettings.tsx
+++ b/src/settings/RendererSettings.tsx
@@ -1,9 +1,7 @@
 import { AriaAttributes, ComponentType, DOMAttributes } from 'react';
 import { useTockSettings } from '../TockContext';
-
-interface RendererRegistry {
-  default: NonNullable<ComponentType<unknown>>;
-}
+import { ButtonRenderers } from './ButtonRenderers';
+import { RendererRegistry } from './RendererRegistry';
 
 export interface TextRendererProps {
   text: string;
@@ -71,6 +69,7 @@ export interface ImageRenderers extends RendererRegistry {
 }
 
 export interface RendererSettings {
+  buttonRenderers: ButtonRenderers;
   imageRenderers: ImageRenderers;
   textRenderers: TextRenderers;
 }
@@ -80,14 +79,22 @@ export const useImageRenderer = (name: keyof ImageRenderers): ImageRenderer => {
   return getRendererOrDefault('ImageRenderer', imageRenderers, name);
 };
 
+export const useButtonRenderer = <K extends keyof ButtonRenderers>(
+  name: K,
+): undefined extends ButtonRenderers[K]
+  ? NonNullable<ButtonRenderers[K]> | ButtonRenderers['default']
+  : ButtonRenderers[K] => {
+  const buttonRenderers = useTockSettings().renderers.buttonRenderers;
+  return getRendererOrDefault('ButtonRenderer', buttonRenderers, name);
+};
+
 function getRendererOrDefault<
   R extends RendererRegistry,
   K extends keyof R & string,
->(type: string, renderers: R, name: K): NonNullable<R[K]> {
-  return (
-    getRenderer(type, renderers, name) ??
-    (getRenderer(type, renderers, 'default') as NonNullable<R[K]>)
-  );
+  V = undefined extends R[K] ? NonNullable<R[K]> | R['default'] : R[K],
+>(type: string, renderers: R, name: K): V {
+  return (getRenderer(type, renderers, name) ??
+    getRenderer(type, renderers, 'default')) as V;
 }
 
 function getRenderer<R extends RendererRegistry, K extends keyof R & string>(

--- a/src/settings/TockSettings.tsx
+++ b/src/settings/TockSettings.tsx
@@ -6,6 +6,7 @@ export interface LocalStorageSettings {
 }
 
 export default interface TockSettings {
+  endPoint?: string;
   localStorage: LocalStorageSettings;
   locale?: string;
   renderers: RendererSettings;

--- a/src/settings/TockSettings.tsx
+++ b/src/settings/TockSettings.tsx
@@ -14,6 +14,14 @@ export default interface TockSettings {
 export const defaultSettings: TockSettings = {
   localStorage: {},
   renderers: {
+    buttonRenderers: {
+      default({ buttonData, children, ...rest }) {
+        return <button {...rest}>{children}</button>;
+      },
+      url({ buttonData, children, ...rest }) {
+        return <a {...rest}>{children}</a>;
+      },
+    },
     imageRenderers: {
       default({ src, alt, ...props }) {
         return <img src={src} alt={alt} {...props} />;

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -118,20 +118,29 @@ function mapImage(image: BotConnectorImage): Image {
 const FINISHED_PROCESSING = -1;
 
 const useTock: (
-  tockEndPoint: string,
+  tockEndPoint?: string,
   extraHeadersProvider?: () => Promise<Record<string, string>>,
   disableSse?: boolean,
   localStorageHistory?: TockLocalStorage,
 ) => UseTock = (
-  tockEndPoint: string,
+  tockEndPointArg?: string,
   extraHeadersProvider?: () => Promise<Record<string, string>>,
   disableSse?: boolean,
   localStorageHistory?: TockLocalStorage,
 ) => {
   const {
+    endPoint: tockEndPointCtx,
     locale,
     localStorage: { prefix: localStoragePrefix },
   } = useTockSettings();
+  if (tockEndPointCtx == null && tockEndPointArg == null) {
+    throw new Error('TOCK endpoint must be provided in TockContext');
+  } else if (tockEndPointCtx == null) {
+    console.warn(
+      'Passing TOCK endpoint as argument to TockChat or useTock is deprecated; please set it in TockContext instead.',
+    );
+  }
+  const tockEndPoint: string = (tockEndPointArg ?? tockEndPointCtx)!;
   const {
     messages,
     quickReplies,


### PR DESCRIPTION
This PR builds upon #161, adding a `buttons` entry to the renderer settings. Some custom buttons may also need to perform network requests to the backend, so I made the `endPoint` parameter available globally through`TockSettings`. The old parameter in `Chat` and `useTock` has been subsequently deprecated and is susceptible to being removed in a future refactor.

Closes #163 