### PR TITLE
resolves #172: refactor message components

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,10 +1,5 @@
 import styled, { StyledComponent } from '@emotion/styled';
-import {
-  DetailedHTMLProps,
-  forwardRef,
-  HTMLAttributes,
-  MutableRefObject,
-} from 'react';
+import { DetailedHTMLProps, HTMLAttributes } from 'react';
 import { theme } from 'styled-tools';
 
 import { Button as ButtonData } from '../../model/buttons';
@@ -18,11 +13,10 @@ import {
 } from '../../settings/RendererSettings';
 
 export const CardOuter: StyledComponent<
-  DetailedHTMLProps<HTMLAttributes<HTMLLIElement>, HTMLLIElement>
-> = styled.li`
+  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+> = styled.div`
   max-width: ${theme('sizing.conversation.width')};
-  margin: 0.5em auto;
-  list-style: none;
+  width: 100%;
 `;
 
 export const CardContainer: StyledComponent<
@@ -125,22 +119,15 @@ export interface CardProps {
   onAction: (button: ButtonData) => void;
 }
 
-const Card = forwardRef<HTMLLIElement, CardProps>(function cardRender(
-  {
-    title,
-    subTitle,
-    imageUrl,
-    imageAlternative,
-    buttons,
-    roleDescription,
-    isHidden = false,
-    onAction,
-  }: CardProps,
-  ref:
-    | ((instance: HTMLLIElement | null) => void)
-    | MutableRefObject<HTMLLIElement | null>
-    | null,
-) {
+const Card = ({
+  title,
+  subTitle,
+  imageUrl,
+  imageAlternative,
+  buttons,
+  isHidden = false,
+  onAction,
+}: CardProps) => {
   const ImageRenderer = useImageRenderer('card');
   const HtmlRenderer = useTextRenderer('htmlPhrase');
   const renderButton = (button: ButtonData, index: number) => (
@@ -164,17 +151,7 @@ const Card = forwardRef<HTMLLIElement, CardProps>(function cardRender(
     </li>
   );
   return (
-    <CardOuter
-      ref={ref}
-      role={ref == undefined ? undefined : 'group'}
-      aria-roledescription={
-        ref == undefined
-          ? undefined
-          : roleDescription
-            ? roleDescription
-            : 'Slide'
-      }
-    >
+    <CardOuter>
       <CardContainer aria-hidden={isHidden}>
         {imageUrl && (
           <ImageRenderer
@@ -197,6 +174,6 @@ const Card = forwardRef<HTMLLIElement, CardProps>(function cardRender(
       </CardContainer>
     </CardOuter>
   );
-});
+};
 
 export default Card;

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { action } from '@storybook/addon-actions';
-import { UrlButton } from '../../model/buttons';
+import { Button, UrlButton } from '../../model/buttons';
 import Carousel from './Carousel';
 import Card, { CardProps } from '../Card';
 
@@ -19,10 +19,10 @@ const cardsWithButtons: CardProps[] = Array.from(Array(CARD_COUNT)).map(
     title: `Card #${i}`,
     imageUrl: 'https://avatars0.githubusercontent.com/u/48585267?s=200&v=4',
     onAction: onButtonClick,
-    buttons: [
-      new UrlButton('Website 1', 'https://sncf.com'),
-      new UrlButton('Website 2', 'https://sncf.com'),
-    ],
+    buttons: Array.from<number, Button>(
+      { length: i % 10 },
+      (_, j) => new UrlButton(`Website ${j}`, 'https://sncf.com'),
+    ) as Button[],
   }),
 );
 

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -14,11 +14,11 @@ import TockAccessibility from 'TockAccessibility';
 import TockTheme from '../../styles/theme';
 
 const ButtonContainer: StyledComponent<
-  DetailedHTMLProps<HTMLAttributes<HTMLLIElement>, HTMLLIElement>
-> = styled.li`
-  margin: 0.4em 0;
+  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+> = styled.div`
+  width: 100%;
   position: relative;
-  list-style: none;
+  overflow-x: auto;
 `;
 
 const ItemContainer: StyledComponent<
@@ -32,6 +32,7 @@ const ItemContainer: StyledComponent<
   touch-action: pan-x pan-y;
   position: relative;
   padding: 0;
+  list-style: none;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -166,17 +167,29 @@ const Carousel: (props: {
         }
         tabIndex={-1}
       >
-        {children?.map((child, i) =>
-          cloneElement(
-            child,
-            {
-              ref: ref.items[i].refObject,
-              roleDescription: accessibility?.carousel?.slideRoleDescription,
-              isHidden: ref.items[i].isHidden,
-            },
-            undefined,
-          ),
-        )}
+        {children?.map((child, i) => {
+          const cardRef = ref.items[i].refObject;
+          return (
+            <li
+              key={`carousel-card-${i}`}
+              ref={cardRef}
+              role={cardRef == undefined ? undefined : 'group'}
+              aria-roledescription={
+                cardRef === undefined
+                  ? undefined
+                  : accessibility?.carousel?.slideRoleDescription ?? 'Slide'
+              }
+            >
+              {cloneElement(
+                child,
+                {
+                  isHidden: ref.items[i].isHidden,
+                },
+                undefined,
+              )}
+            </li>
+          );
+        })}
       </ItemContainer>
       {rightVisible && (
         <Next onClick={next}>

--- a/src/components/Carousel/hooks/useCarousel.ts
+++ b/src/components/Carousel/hooks/useCarousel.ts
@@ -11,7 +11,7 @@ import useRefs from './useRefs';
 import useMeasures, { Measure } from './useMeasures';
 
 type CarouselItem = {
-  refObject: RefObject<HTMLElement>;
+  refObject: RefObject<HTMLLIElement>;
   isHidden: boolean;
   setIsHidden: Dispatch<SetStateAction<boolean>>;
 };

--- a/src/components/Conversation/Conversation.tsx
+++ b/src/components/Conversation/Conversation.tsx
@@ -34,7 +34,7 @@ const ConversationOuterContainer = styled.div`
   flex-direction: column;
 `;
 
-const ConversationInnerContainer = styled.ol`
+const ConversationInnerContainer = styled.ul`
   padding: 0;
   margin: 0;
   flex-grow: 1;

--- a/src/components/Conversation/Conversation.tsx
+++ b/src/components/Conversation/Conversation.tsx
@@ -1,4 +1,4 @@
-import { DetailedHTMLProps, HTMLAttributes } from 'react';
+import { DetailedHTMLProps, HTMLAttributes, RefObject } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 
@@ -33,17 +33,26 @@ const ConversationOuterContainer = styled.div`
   flex-direction: column;
 `;
 
-const ConversationInnerContainer = styled.ul`
+const ConversationInnerContainer = styled.ol`
   padding: 0;
   margin: 0;
   flex-grow: 1;
   flex-shrink: 1;
+  list-style: none;
   overflow-y: scroll;
   scroll-behavior: smooth;
   scrollbar-width: none;
   ::-webkit-scrollbar {
     display: none;
   }
+`;
+
+const ConversationItemLi = styled.li`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin: 0.5em 0;
 `;
 
 interface RenderOptions {
@@ -135,7 +144,9 @@ const Conversation = ({
     );
     const theme: TockTheme = useTheme();
     const displayableMessages = messages.slice(0, displayableMessageCount);
-    const scrollContainer = useScrollBehaviour([displayableMessages]);
+    const scrollContainer: RefObject<HTMLOListElement> = useScrollBehaviour([
+      displayableMessages,
+    ]);
     const renderMessage = (message: Message, index: number) => {
       const render: Renderer = MESSAGE_RENDERER[message.type];
       if (!render) return null;
@@ -144,14 +155,16 @@ const Conversation = ({
           value={message.metadata ?? {}}
           key={`${message.type}-${index}`}
         >
-          {render(
-            message,
-            {
-              widgets,
-              onAction,
-            },
-            accessibility,
-          )}
+          <ConversationItemLi key={`${message.type}-${index}`}>
+            {render(
+              message,
+              {
+                widgets,
+                onAction,
+              },
+              accessibility,
+            )}
+          </ConversationItemLi>
         </MessageMetadataContext>
       );
     };

--- a/src/components/Conversation/hooks/useScrollBehaviour.ts
+++ b/src/components/Conversation/hooks/useScrollBehaviour.ts
@@ -1,9 +1,9 @@
 import { useRef, RefObject, useEffect, DependencyList } from 'react';
 
-export default function useScrollBehaviour(
+export default function useScrollBehaviour<E extends HTMLElement>(
   deps: DependencyList,
-): RefObject<HTMLUListElement> {
-  const container: RefObject<HTMLUListElement> = useRef<HTMLUListElement>(null);
+): RefObject<E> {
+  const container: RefObject<E> = useRef<E>(null);
   useEffect(() => {
     const { current } = container;
     if (!current) return;

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -5,12 +5,11 @@ import '../../styles/theme';
 import { css, Interpolation, Theme } from '@emotion/react';
 import { useImageRenderer } from '../../settings/RendererSettings';
 
-export const ImageOuter: StyledComponent<
-  DetailedHTMLProps<HTMLAttributes<HTMLLIElement>, HTMLLIElement>
-> = styled.li`
+const ImageOuter: StyledComponent<
+  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+> = styled.div`
   max-width: ${prop('theme.sizing.conversation.width')};
-  margin: 0.5em auto;
-  list-style: none;
+  width: 100%;
 `;
 
 export const ImageContainer: StyledComponent<
@@ -40,7 +39,7 @@ export interface ImageProps {
   alternative?: string;
 }
 
-const Image = forwardRef<HTMLLIElement, ImageProps>(function imageRender(
+const Image = forwardRef<HTMLDivElement, ImageProps>(function imageRender(
   { url: src, alternative: alt }: ImageProps,
   ref,
 ) {

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -9,7 +9,6 @@ const LoaderContainer: StyledComponent<
 > = styled.div`
   width: 100%;
   max-width: ${prop('theme.sizing.conversation.width')};
-  margin: 0.5em auto;
 `;
 
 const BulletList = styled.div`

--- a/src/components/MessageBot/MessageBot.tsx
+++ b/src/components/MessageBot/MessageBot.tsx
@@ -9,12 +9,10 @@ import { useTextRenderer } from '../../settings/RendererSettings';
 import { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 export const MessageContainer: StyledComponent<
-  DetailedHTMLProps<HTMLAttributes<HTMLLIElement>, HTMLLIElement>
-> = styled.li`
+  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+> = styled.div`
   width: 100%;
   max-width: ${theme('sizing.conversation.width')};
-  margin: 0.5em auto;
-  list-style: none;
 
   p {
     margin: 0;

--- a/src/components/MessageUser/MessageUser.tsx
+++ b/src/components/MessageUser/MessageUser.tsx
@@ -6,7 +6,7 @@ import { MessageContainer as BotMessageContainer } from '../MessageBot';
 import { useTextRenderer } from '../../settings/RendererSettings';
 
 const MessageContainer: StyledComponent<
-  DetailedHTMLProps<HTMLAttributes<HTMLLIElement>, HTMLLIElement>
+  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
 > = styled(BotMessageContainer)`
   text-align: right;
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ export {
   MessageContainer,
   Message,
 } from './components/MessageBot';
+export { default as PostbackButton } from './components/buttons/PostBackButton';
 export { default as MessageUser } from './components/MessageUser';
 export { default as QuickReply } from './components/QuickReply';
 export { default as QuickReplyList } from './components/QuickReplyList';
+export { default as InlineQuickReplyList } from './components/InlineQuickReplyList';
 export { renderChat } from './renderChat';
 export { default as TockContext, useTockSettings } from './TockContext';
 export { default as useTock } from './useTock';
@@ -35,6 +37,7 @@ export type {
   Carousel as CarouselData,
   Image as ImageData,
   Message as MessageData,
+  MessageType,
   TextMessage as TextMessageData,
   Widget as WidgetData,
   WidgetPayload,
@@ -45,7 +48,10 @@ export type {
 } from './PostInitContext';
 export type { default as TockTheme } from './styles/theme';
 export type { default as TockOptions } from './TockOptions';
-export type { default as TockSettings } from './settings/TockSettings';
+export type {
+  default as TockSettings,
+  LocalStorageSettings,
+} from './settings/TockSettings';
 export type {
   ImageRenderer,
   TextRenderer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,12 @@ export type {
   UrlButton as UrlButtonData,
   QuickReply as QuickReplyData,
 } from './model/buttons';
+export { MessageType } from './model/messages';
 export type {
   Card as CardData,
   Carousel as CarouselData,
   Image as ImageData,
   Message as MessageData,
-  MessageType,
   TextMessage as TextMessageData,
   Widget as WidgetData,
   WidgetPayload,


### PR DESCRIPTION
resolves #172 by turning `li`s into `div`s, and moving/merging the associated styling to the `Conversation` component. In the same manner, the carousel-specific logic in the `Card` component has been moved to the `Carousel`.