### PR TITLE
resolves #176: add handling for network errors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,13 +349,14 @@ A `TockTheme` can be used as a value of a `ThemeProvider` of [`emotion-theming`]
 
 #### `RendererSettings`
 
-| Property name     | Type               | Description                                                                   |
-|-------------------|--------------------|-------------------------------------------------------------------------------|
-| `buttonRenderers` | `ButtonRenderers?` | Configuration of renderers for buttons displayed in the chat interface        |
-| `imageRenderers`  | `ImageRenderers?`  | Configuration of renderers for dynamic images displayed in the chat interface |
-| `textRenderers`   | `TextRenderers?`   | Configuration of renderers for dynamic text displayed in the chat interface   |
+| Property name      | Type                | Description                                                                        |
+|--------------------|---------------------|------------------------------------------------------------------------------------|
+| `buttonRenderers`  | `ButtonRenderers?`  | Configuration of renderers for buttons displayed in the chat interface             |
+| `imageRenderers`   | `ImageRenderers?`   | Configuration of renderers for dynamic images displayed in the chat interface      |
+| `messageRenderers` | `MessageRenderers?` | Configuration of renderers for individual message components in the chat interface |
+| `textRenderers`    | `TextRenderers?`    | Configuration of renderers for dynamic text displayed in the chat interface        |
 
-#### `ButtonRendererSettings`
+#### `ButtonRenderers`
 
 Button renderers all implement some specialization of the `ButtonRenderer` interface.
 They are tasked with rendering a graphical component using button-specific data, a class name, and other generic HTML attributes.
@@ -368,7 +369,7 @@ The passed in class name provides the default style for the rendered component, 
 | `postback`    | `PostBackButtonRenderer?`   | Renders a `PostBackButton`                                                                           |
 | `quickReply`  | `QuickReplyButtonRenderer?` | Renders a `QuickReply`                                                                               |
 
-#### `ImageRendererSettings`
+#### `ImageRenderers`
 
 Image renderers all implement the `ImageRenderer` interface.
 They are tasked with rendering a graphical component using a source URL, a description, a class name, and other generic HTML attributes.
@@ -381,7 +382,17 @@ The passed in class name provides the default style for the rendered component, 
 | `card`        | Renders images in the card component (including in carousels)                                     |
 | `buttonIcon`  | Renders icons in quick replies, URL buttons, and postback buttons                                 |
 
-#### `TextRendererSettings`
+#### `MessageRenderers`
+
+Message renderers are tasked with rendering individual messages exchanged between the bot and the user.
+Currently, the only message renderer that can be defined here is for the `error` message - a special message that only
+appears after a network error (and disappears after a successful request).
+
+| Property name | Description                                                                          |
+|---------------|--------------------------------------------------------------------------------------|
+| `error`       | The error message renderer. If left unspecified, no error message is ever displayed. |
+
+#### `TextRenderers`
 
 Text renderers all implement the `TextRenderer` interface.
 They are tasked with rendering a string into a text component.

--- a/src/TockContext.tsx
+++ b/src/TockContext.tsx
@@ -55,6 +55,7 @@ export interface TockState {
   loading: boolean;
   sseInitializing: boolean;
   metadata: Record<string, string>;
+  error: boolean;
 }
 
 export interface TockAction {
@@ -64,12 +65,14 @@ export interface TockAction {
     | 'SET_METADATA'
     | 'SET_LOADING'
     | 'SET_SSE_INITIALIZING'
-    | 'CLEAR_MESSAGES';
+    | 'CLEAR_MESSAGES'
+    | 'SET_ERROR';
   quickReplies?: QuickReply[];
   messages?: Message[];
   loading?: boolean;
   sseInitializing?: boolean;
   metadata?: Record<string, string>;
+  error?: boolean;
 }
 
 const tockReducer: Reducer<TockState, TockAction> = (
@@ -82,6 +85,7 @@ const tockReducer: Reducer<TockState, TockAction> = (
         return {
           ...state,
           quickReplies: action.quickReplies,
+          error: !!action.error,
         };
       }
       break;
@@ -90,6 +94,7 @@ const tockReducer: Reducer<TockState, TockAction> = (
         return {
           ...state,
           messages: [...state.messages, ...action.messages],
+          error: !!action.error,
         };
       }
       break;
@@ -106,6 +111,7 @@ const tockReducer: Reducer<TockState, TockAction> = (
         return {
           ...state,
           sseInitializing: action.sseInitializing,
+          error: !!action.error,
         };
       }
       break;
@@ -125,6 +131,11 @@ const tockReducer: Reducer<TockState, TockAction> = (
         };
       }
       break;
+    case 'SET_ERROR':
+      return {
+        ...state,
+        error: !!action.error,
+      };
     default:
       break;
   }
@@ -149,6 +160,7 @@ const TockContext: (props: {
     loading: false,
     sseInitializing: false,
     metadata: {},
+    error: false,
   });
   return (
     <TockSettingsContext.Provider value={mergedSettings}>

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { JSX, useEffect } from 'react';
 import useTock, { UseTock } from '../../useTock';
 import ChatInput from '../ChatInput';
 import Container from '../Container';
@@ -52,6 +52,7 @@ const Chat: (props: ChatProps) => JSX.Element = ({
     sseInitPromise,
     sseInitializing,
     clearMessages,
+    error,
   }: UseTock = useTock(
     endPoint,
     extraHeadersProvider,
@@ -90,6 +91,7 @@ const Chat: (props: ChatProps) => JSX.Element = ({
         messageDelay={timeoutBetweenMessage}
         widgets={widgets}
         loading={loading}
+        error={error}
         quickReplies={quickReplies}
         onAction={sendAction}
         onQuickReplyClick={sendQuickReply}

--- a/src/components/Conversation/Conversation.tsx
+++ b/src/components/Conversation/Conversation.tsx
@@ -27,6 +27,7 @@ import type {
   Widget,
 } from '../../model/messages';
 import { MessageMetadataContext } from '../../MessageMetadata';
+import { useTockSettings } from '../../TockContext';
 
 const ConversationOuterContainer = styled.div`
   display: flex;
@@ -110,6 +111,7 @@ type Props = DetailedHTMLProps<
   messageDelay: number;
   widgets?: { [id: string]: (props: unknown) => JSX.Element };
   loading?: boolean;
+  error?: boolean;
   quickReplies: QuickReply[];
   onAction: (button: Button) => void;
   onQuickReplyClick: (button: Button) => void;
@@ -120,6 +122,7 @@ const Conversation = ({
   messages,
   messageDelay,
   loading = false,
+  error = false,
   onAction,
   widgets = {},
   onQuickReplyClick,
@@ -136,6 +139,8 @@ const Conversation = ({
     const theme: TockTheme = useTheme();
     const displayableMessages = messages.slice(0, displayableMessageCount);
     const scrollContainer = useScrollBehaviour([displayableMessages]);
+    const ErrorMessageRenderer =
+      useTockSettings().renderers.messageRenderers.error;
     const renderMessage = (message: Message, index: number) => {
       const render: Renderer = MESSAGE_RENDERER[message.type];
       if (!render) return null;
@@ -166,6 +171,7 @@ const Conversation = ({
         <ConversationInnerContainer ref={scrollContainer}>
           {displayableMessages.map(renderMessage)}
           {loading && <Loader />}
+          {error && ErrorMessageRenderer && <ErrorMessageRenderer />}
         </ConversationInnerContainer>
         {!loading &&
           displayableMessageCount === messages.length &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,9 @@ export type {
   ImageRenderer,
   TextRenderer,
   RendererSettings,
-  TextRenderers,
   ImageRenderers,
+  MessageRenderers,
+  TextRenderers,
 } from './settings/RendererSettings';
 export type {
   ButtonRenderers,

--- a/src/settings/RendererSettings.tsx
+++ b/src/settings/RendererSettings.tsx
@@ -68,9 +68,14 @@ export interface ImageRenderers extends RendererRegistry {
   buttonIcon?: ImageRenderer;
 }
 
+export interface MessageRenderers {
+  error?: ComponentType;
+}
+
 export interface RendererSettings {
   buttonRenderers: ButtonRenderers;
   imageRenderers: ImageRenderers;
+  messageRenderers: MessageRenderers;
   textRenderers: TextRenderers;
 }
 

--- a/src/settings/TockSettings.tsx
+++ b/src/settings/TockSettings.tsx
@@ -28,6 +28,7 @@ export const defaultSettings: TockSettings = {
         return <img src={src} alt={alt} {...props} />;
       },
     },
+    messageRenderers: {},
     textRenderers: {
       default({ text }) {
         return text;

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -226,42 +226,44 @@ const useTock: (
       }
       dispatch({
         type: 'ADD_MESSAGE',
-        messages: responses.map(
-          ({ text, card, carousel, widget, image, buttons }) => {
-            let message: Message;
-            if (widget) {
-              message = {
-                widgetData: widget,
-                type: MessageType.widget,
-              } as Widget;
-            } else if (text) {
-              message = {
-                author: 'bot',
-                message: text,
-                type: MessageType.message,
-                buttons: (buttons || [])
-                  .filter((button) => button.type !== 'quick_reply')
-                  .map(mapButton),
-              } as TextMessage;
-            } else if (card) {
-              message = mapCard(card);
-            } else if (image) {
-              message = mapImage(image);
-            } else {
-              message = {
-                cards: carousel?.cards?.map(mapCard) ?? [],
-                type: MessageType.carousel,
-              } as Carousel;
-            }
+        messages: responses.flatMap((response) => {
+          const { text, card, carousel, widget, image, buttons } = response;
+          let message: Message;
+          if (widget) {
+            message = {
+              widgetData: widget,
+              type: MessageType.widget,
+            } as Widget;
+          } else if (text) {
+            message = {
+              author: 'bot',
+              message: text,
+              type: MessageType.message,
+              buttons: (buttons || [])
+                .filter((button) => button.type !== 'quick_reply')
+                .map(mapButton),
+            } as TextMessage;
+          } else if (card) {
+            message = mapCard(card);
+          } else if (image) {
+            message = mapImage(image);
+          } else if (carousel) {
+            message = {
+              cards: carousel.cards.map(mapCard),
+              type: MessageType.carousel,
+            } as Carousel;
+          } else {
+            console.error('Unsupported bot response', response);
+            return [];
+          }
 
-            message.metadata = metadata;
+          message.metadata = metadata;
 
-            if (localStorageHistory?.enable ?? false) {
-              recordResponseToLocaleSession(message);
-            }
-            return message;
-          },
-        ),
+          if (localStorageHistory?.enable ?? false) {
+            recordResponseToLocaleSession(message);
+          }
+          return [message];
+        }),
       });
     }
   };

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -34,6 +34,7 @@ export interface UseTock {
   messages: Message[];
   quickReplies: QuickReply[];
   loading: boolean;
+  error: boolean;
   addMessage: (
     message: string,
     author: 'bot' | 'user',
@@ -147,6 +148,7 @@ const useTock: (
     userId,
     loading,
     sseInitializing,
+    error,
   }: TockState = useTockState();
   const dispatch: Dispatch<TockAction> = useTockDispatch();
   const { clearMessages }: UseLocalTools = useLocalTools(
@@ -362,6 +364,20 @@ const useTock: (
     [],
   );
 
+  const handleError: (error: unknown) => void = ({ error }) => {
+    console.error(error);
+    stopLoading();
+    setQuickReplies([]);
+    if (localStorage) {
+      window.localStorage.setItem('tockQuickReplyHistory', '');
+    }
+    dispatch({
+      type: 'SET_ERROR',
+      error: true,
+      loading: false,
+    });
+  };
+
   const getExtraHeaders: () => Promise<Record<string, string>> =
     extraHeadersProvider ?? (async () => ({}));
 
@@ -407,7 +423,7 @@ const useTock: (
         },
       })
         .then((res) => res.json())
-        .then(handlePostBotResponse)
+        .then(handlePostBotResponse, handleError)
         .finally(stopLoading);
     },
     [locale],
@@ -428,7 +444,7 @@ const useTock: (
         },
       })
         .then((res) => res.json())
-        .then(handlePostBotResponse)
+        .then(handlePostBotResponse, handleError)
         .finally(stopLoading);
     }, []);
 
@@ -475,7 +491,7 @@ const useTock: (
       },
     })
       .then((res) => res.json())
-      .then(handlePostBotResponse)
+      .then(handlePostBotResponse, handleError)
       .finally(stopLoading);
   }
 
@@ -636,6 +652,7 @@ const useTock: (
     messages,
     quickReplies,
     loading,
+    error,
     clearMessages,
     addCard,
     addCarousel,


### PR DESCRIPTION
This PR resolves #176 by adding an `error` property to the `TockState`, which is set to `true` when a network error occurs and set back to `false` whenever a request to the backend succeeds. When an error message renderer is defined in the `TockSettings`, that renderer is used to display a custom message in the chat, which disappears once the error is resolved.

## Considerations

The `error` field could be named `networkError` instead, to leave room for other types of errors in the future. On the other hand, leaving it generic means we can add more properties in the future, allowing a single error renderer to handle a variety of error types.
