### PR TITLE
fix #183: update publication workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,9 +34,9 @@ jobs:
       #- run: yarn config set version-sign-git-tag true
       - run: |
               if [[ ${{ github.event.inputs.version }} == *"-"* ]]; then
-                  yarn publish -- ${{ github.event.inputs.version }} --tag=beta
+                  yarn publish --new-version ${{ github.event.inputs.version }} --tag=beta
               else
-                  yarn publish ${{ github.event.inputs.version }}
+                  yarn publish --new-version ${{ github.event.inputs.version }}
               fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,10 +33,11 @@ jobs:
       - run: git config --local user.name "GitHub Action"
       #- run: yarn config set version-sign-git-tag true
       - run: |
-              if [ ${{ github.event.client_payload.version }} == "prerelease" ]; then
-                  yarn run release ${{ github.event.client_payload.version }} --tag=beta
+              if [[ ${{ github.event.inputs.version }} == *"-"* ]]; then
+                  yarn publish -- ${{ github.event.inputs.version }} --tag=beta
               else
-                  yarn run release ${{ github.event.client_payload.version }}
-              fi 
+                  yarn publish ${{ github.event.inputs.version }}
+              fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: git push

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -4,24 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release: "X.Y.Z" or "prerelease" for beta'
+        description: 'Version to release: "X.Y.Z", or "X.Y.Z-beta" for beta'
         required: true
-        default: 'prerelease'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Get tag number
-        id: get_tag
-        run: echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3)
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: 'blob:none'
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -31,16 +30,16 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install
       - run: git config --local user.email "action@github.com"
       - run: git config --local user.name "GitHub Action"
       #- run: yarn config set version-sign-git-tag true
       - run: |
-              if [ ${{ github.event.inputs.version }} == "prerelease" ]; then
-                  yarn run release ${{ github.event.inputs.version }} --tag=beta
+              if [[ ${{ github.event.inputs.version }} == *"-"* ]]; then
+                  yarn publish --new-version ${{ github.event.inputs.version }} --tag=beta
               else
-                  yarn run release ${{ github.event.inputs.version }}
-              fi 
+                  yarn publish --new-version ${{ github.event.inputs.version }}
+              fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: git push --tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,26 +17,27 @@
     * [@vsct-jburet](https://github.com/vsct-jburet)
     * [@MaximeLeFrancois](https://github.com/MaximeLeFrancois)
     * [@delphes99](https://github.com/delphes99)
+    * [@Fabilin](https://github.com/Fabilin)
     
 # GITHUB ACTION FOR PUBLISHING
 
 ## Build, tag and publish new version
 
-Warning: "Require signed commits" on master branch must be unchecked (https://github.com/theopenconversationkit/tock-react-kit/settings/branch_protection_rules/11667069)
+1. Ensure a milestone exists for the new version (https://github.com/theopenconversationkit/tock-react-kit/milestones)
+   and that all relevant issues are assigned to it
+2. Run the [manual release workflow](https://github.com/theopenconversationkit/tock-react-kit/actions/workflows/manual.yaml)
+   with the new version number
+3. Create a [GitHub release](https://github.com/theopenconversationkit/tock-react-kit/releases) using the tag created by the workflow
 
-    curl \
-      -H "Accept: application/vnd.github.everest-preview+json" \
-      -H "Authorization: token xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
-      --request POST \
-      --data '{"event_type": "publish", "client_payload": {"version": "X.Y.Z"} }'
-      https://api.github.com/repos/theopenconversationkit/tock-react-kit/dispatches
+### Versioning
 
-You can also build a beta version using "prerelease" keyword
+Our versioning is based on [Semantic Versioning](https://semver.org), with some tweaks to tie the version to our release schedule:
+- The major and minor components are repurposed to denote respectively the release year and month of the current major version.
+  We release two major versions per year, one in March and one in September.
+- The patch version component keeps the same meaning as in semver. We release patch versions at any time.
+- The additional labels for pre-release and build metadata keep the same meaning as in semver
 
-    curl \
-      -H "Accept: application/vnd.github.everest-preview+json" \
-      -H "Authorization: token xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
-      --request POST \
-      --data '{"event_type": "publish", "client_payload": {"version": "prerelease"} }'
-      https://api.github.com/repos/theopenconversationkit/tock-react-kit/dispatches
-      
+For example:
+- 23.3.0 is the major version released in March 2023. The next major version is 23.9.0, released in September of the same year.
+- 23.9.2 is the second patch version for the 23.9 major, and may be released any time between September 2023 and March 2024.
+- 24.9.0-beta.1 is the first beta for the upcoming 24.9.0 major version.


### PR DESCRIPTION
Fixes #183 by switching the publication logic to stock [yarn publish](https://classic.yarnpkg.com/lang/en/docs/cli/publish/).
All the GitHub actions in the workflow have also been updated to their latest version, and the `git fetch` command has been replaced with a lightweight fetch configured directly in the `checkout` action (`filter` being a new parameter in `actions/checkout` v4).

The new workflow does not allow using `prerelease` as an argument, instead any version containing a dash (e.g. `24.9.0-prerelease`) will be released with the `beta` NPM tag.