### PR TITLE
resolves #190: add `historyMaxAge` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,11 +352,12 @@ Objects implementing this interface can be passed to `renderChat` or to `TockCon
 
 #### `LocalStorageSettings`
 
-| Property name          | Type       | Description                                                                                                                                 |
-|------------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `enableMessageHistory` | `boolean?` | If set to `true`, the most recent messages of a conversation will be persisted in the local storage. Defaults to `false`.                   |
-| `maxMessageCount`      | `number?`  | When message history is enabled, sets the max number of messages to store. Defaults to 10.                                                  |
-| `prefix`               | `string?`  | Prefix for local storage keys allowing communication with different bots from the same domain (used for both `userId` and message history). |
+| Property name          | Type       | Description                                                                                                                                                |
+|------------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `enableMessageHistory` | `boolean?` | If set to `true`, the most recent messages of a conversation will be persisted in the local storage. Defaults to `false`.                                  |
+| `historyMaxAge`        | `number?`  | If set to a positive value, represents the number of seconds before the message history is cleared (the timeout is reset after each message received).     |
+| `maxMessageCount`      | `number?`  | When message history is enabled, sets the max number of messages to store. Defaults to 10.                                                                 |
+| `prefix`               | `string?`  | Prefix for local storage keys allowing communication with different bots from the same domain (used for both `userId` and message history).                |
 
 #### `NetworkSettings`
 

--- a/src/settings/TockSettings.tsx
+++ b/src/settings/TockSettings.tsx
@@ -6,6 +6,7 @@ export interface LocalStorageSettings {
   prefix: string;
   enableMessageHistory: boolean;
   maxMessageCount: number;
+  historyMaxAge: number;
 }
 
 export interface NetworkSettings {
@@ -28,6 +29,7 @@ export const defaultSettings: TockSettings = {
     prefix: '',
     enableMessageHistory: false,
     maxMessageCount: 10,
+    historyMaxAge: -1,
   },
   network: {
     disableSse: false,

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -673,7 +673,7 @@ export const useTock0: (
         const lastMessageTime = +(
           window.localStorage.getItem(messageHistoryLastTimeKey) ?? 0
         );
-        if (historyMaxAge > (Date.now() - lastMessageTime) / 1000) {
+        if ((Date.now() - lastMessageTime) / 1000 > historyMaxAge) {
           window.localStorage.removeItem(messageHistoryLSKey);
           window.localStorage.removeItem(quickReplyHistoryLSKey);
           window.localStorage.removeItem(messageHistoryLastTimeKey);

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -670,9 +670,10 @@ export const useTock0: (
     if (serializedHistory) {
       const historyMaxAge = localStorageSettings.historyMaxAge;
       if (historyMaxAge > 0) {
-        const lastMessageTime =
-          window.localStorage.getItem(messageHistoryLastTimeKey) ?? 0;
-        if (historyMaxAge > (Date.now() - +lastMessageTime) / 1000) {
+        const lastMessageTime = +(
+          window.localStorage.getItem(messageHistoryLastTimeKey) ?? 0
+        );
+        if (historyMaxAge > (Date.now() - lastMessageTime) / 1000) {
           window.localStorage.removeItem(messageHistoryLSKey);
           window.localStorage.removeItem(quickReplyHistoryLSKey);
           window.localStorage.removeItem(messageHistoryLastTimeKey);


### PR DESCRIPTION
Resolves #190 by introducing a mechanism to clean up local storage data for TOCK message history and quick replies based on a configurable `historyMaxAge`. If the age of the last message exceeds the defined maximum age, the relevant local storage keys are removed to ensure outdated data is not retained.

The `historyMaxAge` property is based on the `tock_web_cookie_auth_max_age` property configurable in the backend and is intended to be set to the same value.