### PR TITLE
resolves #192 Add support for streaming LLM responses with message up…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ You can use createTheme function to init a valid theme.
 renderChat(document.getElementById('chat'), '<TOCK_BOT_API_URL>', 'referralParameter', createTheme({}));
 ```
 
+### Default classes
+
+If the MetadataEvent `TOCK_STREAM_RESPONSE` is set to true, the tock-react-kit will add the css class `tock-streamed-response` to the message element.
+
+It allows the client to customize the appearance of streamed responses.
+
+
 ## Customize interface
 
 If the chat does not suit your needs, there are two main ways to customize the interface rendering.
@@ -206,6 +213,11 @@ The metadata from each response is also attached to the corresponding messages.
 This metadata is persisted with the messages, including through page reloads if [local storage history](#local-storage-history) is enabled.
 It is available to [custom renderers](#configure-custom-renderers) through the use of the `useMessageMetadata` hook,
 as well as to custom React-based frontends that handle message rendering themselves.
+
+### Streamed responses
+
+In order to support the streaming of responses, when the MetadataEvent `TOCK_STREAM_RESPONSE` is set to true, a message with the same responseId will be replaced with the new version of the message.
+
 
 ## API Reference
 

--- a/src/useTock.ts
+++ b/src/useTock.ts
@@ -231,6 +231,7 @@ export const useTock0: (
           const quickReplies = (lastMessage.buttons || [])
             .filter((button) => button.type === 'quick_reply')
             .map(mapButton);
+
           dispatch({
             type: 'SET_QUICKREPLIES',
             quickReplies,
@@ -245,8 +246,11 @@ export const useTock0: (
               JSON.stringify(quickReplies),
             );
           }
+
           dispatch({
-            type: 'ADD_MESSAGE',
+            type: metadata?.TOCK_STREAM_RESPONSE
+              ? 'UPDATE_MESSAGE'
+              : 'ADD_MESSAGE',
             messages: responses.flatMap((response) => {
               const { text, card, carousel, widget, image, buttons } = response;
               let message: Message;
@@ -255,7 +259,7 @@ export const useTock0: (
                   widgetData: widget,
                   type: MessageType.widget,
                 } as Widget;
-              } else if (text) {
+              } else if (text !== undefined) {
                 message = {
                   author: 'bot',
                   message: text,
@@ -397,7 +401,7 @@ export const useTock0: (
     [],
   );
 
-  const handleError: (error: unknown) => void = ({ error }) => {
+  const handleError: (error: unknown) => void = (error) => {
     console.error(error);
     stopLoading();
     setQuickReplies([]);


### PR DESCRIPTION
…dates### Implementation Details
The solution uses a metadata flag `TOCK_STREAM_RESPONSE` sent by the server to indicate that:

1. The response is being streamed
2. Messages with the same RESPONSE_ID should be updated rather than appended

### Changes Made
1. New Reducer Case (UPDATE_MESSAGE)
```
case 'UPDATE_MESSAGE':
  if (action.messages) {
    let messageAlreadyExists = false;

    const newMessages = state.messages.map((message) => {
      // Search if a streamed message with the same responseId already exists
      const messageExists = action.messages?.find((m) => {
        const isMessageExists =
          m.metadata?.RESPONSE_ID === message.metadata?.RESPONSE_ID &&
          m.metadata?.TOCK_STREAM_RESPONSE === 'true' &&
          message.metadata?.TOCK_STREAM_RESPONSE === 'true';

        if (isMessageExists) {
          messageAlreadyExists = true;
        }

        return isMessageExists;
      });

      // If the message already exists, replace with the new message
      if (messageExists) {
        return messageExists;
      }

      // Else return the original message
      return message;
    });

    // If the message is new, add it to the messages
    if (!messageAlreadyExists) {
      newMessages.push(...action.messages);
    }

    return {
      ...state,
      messages: newMessages,
      error: !!action.error,
    };
  }
  break;
```

2. Conditional Dispatch Logic
The dispatch now checks for the `TOCK_STREAM_RESPONSE` metadata flag to determine whether to update or add a message:

```
dispatch({
  type: metadata?.TOCK_STREAM_RESPONSE
    ? 'UPDATE_MESSAGE'
    : 'ADD_MESSAGE',
  messages: responses.flatMap((response) => {
    // ... message mapping logic
    message.metadata = metadata;
    
    if (localStorageEnabled) {
      recordResponseToLocalSession(message);
    }
    return [message];
  }),
});

```

### Expected Behavior
**Without streaming (current behavior):**

- Server sends complete message
- `ADD_MESSAGE` action is dispatched
- New message appears in the chat

**With streaming (new behavior):**

1. Server sends first chunk with metadata: `{ TOCK_STREAM_RESPONSE: 'true', RESPONSE_ID: 'unique-id' }`
2. `UPDATE_MESSAGE` action is dispatched
3. Message is added to the chat (since it doesn't exist yet)
4. Server sends subsequent chunks with the same `RESPONSE_ID`
5. `UPDATE_MESSAGE` action updates the existing message in place
6. User sees the message text gradually appear, similar to ChatGPT's streaming effect

### Testing
This change has been tested with:

- [X]  Streaming responses from LLM
- [X]  Non-streaming responses (backward compatibility)
- [X]  Multiple concurrent streamed messages
- [X] Error handling during streaming