### PR TITLE
fixes #193: fix default `renderers` settings assignment

### DIFF
--- a/src/renderChat.tsx
+++ b/src/renderChat.tsx
@@ -21,8 +21,9 @@ export const renderChat: (
   theme: TockTheme = defaultTheme,
   {
     locale,
+    // Default empty values are required for the merge with default settings
     localStorage = {},
-    renderers,
+    renderers = {},
     network = {},
     ...options
   }: TockOptions = {},


### PR DESCRIPTION
Fixes #193 

The issue was caused by an `undefined` variable overriding the default value for the `renderers` property. This PR adds a default empty value for this variable, allowing `deepmerge` to work as expected.